### PR TITLE
feat: 자유게시판 조회기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/ActiveStatus.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/ActiveStatus.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.board.aggregate.entity;
+
+public enum ActiveStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/Board.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/Board.java
@@ -1,0 +1,49 @@
+package com.threeping.mudium.board.aggregate.entity;
+
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "TBL_BOARD")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class Board {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private int boardId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    @Column(name = "like")
+    private Long like;
+
+    @Column(name = "active_status")
+    @Enumerated(EnumType.STRING)
+    private ActiveStatus activeStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
@@ -1,0 +1,37 @@
+package com.threeping.mudium.board.controller;
+
+import com.threeping.mudium.board.dto.BoardDetailDTO;
+import com.threeping.mudium.board.dto.BoardListDTO;
+import com.threeping.mudium.board.service.BoardService;
+import com.threeping.mudium.common.ResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/board")
+public class BoardController {
+
+    private BoardService boardService;
+
+    @Autowired
+    private BoardController(BoardService boardService){
+        this.boardService = boardService;
+    }
+
+    @GetMapping("")
+    private ResponseDTO<?> viewBoardPage(Pageable pageable){
+        Page<BoardListDTO> boardPage = boardService.viewBoardList(pageable);
+        return ResponseDTO.ok(boardPage);
+    }
+
+    @GetMapping("/detail/{boardId}")
+    private ResponseDTO<?> viewDetailBoard(@PathVariable Long boardId){
+        BoardDetailDTO boardDetail = boardService.viewBoard(boardId);
+        return ResponseDTO.ok(boardDetail);
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardDetailDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardDetailDTO.java
@@ -1,0 +1,20 @@
+package com.threeping.mudium.board.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class BoardDetailDTO {
+    private Long id;
+    private String title;
+    private String content;
+    private String nickname;
+    private Long userId;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardListDTO.java
@@ -1,0 +1,18 @@
+package com.threeping.mudium.board.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class BoardListDTO {
+    private Long id;
+    private String title;
+    private String nickname;
+    private Long userId;
+    private Timestamp createdAt;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/repository/BoardRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/repository/BoardRepository.java
@@ -1,0 +1,9 @@
+package com.threeping.mudium.board.repository;
+
+import com.threeping.mudium.board.aggregate.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board,Long> {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardService.java
@@ -1,0 +1,12 @@
+package com.threeping.mudium.board.service;
+
+import com.threeping.mudium.board.dto.BoardDetailDTO;
+import com.threeping.mudium.board.dto.BoardListDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BoardService {
+    Page<BoardListDTO> viewBoardList(Pageable pageable);
+
+    BoardDetailDTO viewBoard(Long boardId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardServiceImpl.java
@@ -1,0 +1,71 @@
+package com.threeping.mudium.board.service;
+
+import com.threeping.mudium.board.aggregate.entity.Board;
+import com.threeping.mudium.board.dto.BoardDetailDTO;
+import com.threeping.mudium.board.dto.BoardListDTO;
+import com.threeping.mudium.board.repository.BoardRepository;
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class BoardServiceImpl implements BoardService {
+
+    private final BoardRepository boardRepository;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    BoardServiceImpl(BoardRepository boardRepository,
+                     ModelMapper modelMapper){
+        this.boardRepository = boardRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    @Transactional
+    public Page<BoardListDTO> viewBoardList(Pageable pageable) {
+
+        int pageNumber = pageable.getPageNumber()<=1 ? 0 : pageable.getPageNumber() - 1;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable boardPageable = PageRequest.of(pageNumber,pageSize,pageSort);
+
+        Page<Board> boards = boardRepository.findAll(boardPageable);
+
+        if (boards.getTotalPages()<pageNumber) {
+            Pageable maxPageable = PageRequest.of(boards.getTotalPages()-1,pageSize,pageSort);
+            boards = boardRepository.findAll(maxPageable);
+        }
+
+        List<BoardListDTO> boardListDTOList = boards.stream()
+                .map(board -> {
+                    BoardListDTO boardListDTO = modelMapper.map(board, BoardListDTO.class);
+                    boardListDTO.setNickname(board.getUser().getNickname());
+                    return boardListDTO;
+                })
+                .collect(Collectors.toList());
+        Page<BoardListDTO> boardListDTOs = new PageImpl<>(boardListDTOList,pageable,boards.getTotalElements());
+
+        return boardListDTOs;
+    }
+
+    @Override
+    @Transactional
+    public BoardDetailDTO viewBoard(Long boardId) {
+
+        Board board = boardRepository.findById(boardId).orElseThrow(()->new CommonException(ErrorCode.INVALID_BOARD_ID));
+        BoardDetailDTO boardDetailDTO = modelMapper.map(board, BoardDetailDTO.class);
+        boardDetailDTO.setNickname(board.getUser().getNickname());
+
+        return boardDetailDTO;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_REQUEST_BODY(40011, HttpStatus.BAD_REQUEST, "잘못된 요청 본문입니다."),
     MISSING_REQUIRED_FIELD(40012, HttpStatus.BAD_REQUEST, "필수 필드가 누락되었습니다."),
     INVALID_VERIFICATION_CODE(40013, HttpStatus.BAD_REQUEST, "잘못된 인증번호입니다. 인증번호를 다시 확인해주세요"),
+    INVALID_BOARD_ID(40021,HttpStatus.BAD_REQUEST,"잘못된 자유게시글 번호입니다."),
 
     // 파일 관련 오류
     UNSUPPORTED_FILE_FORMAT(40020, HttpStatus.BAD_REQUEST, "지원되지 않는 파일 형식입니다."),

--- a/MUDIUM/src/test/java/com/threeping/mudium/board/service/BoardServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/board/service/BoardServiceImplTests.java
@@ -1,0 +1,56 @@
+package com.threeping.mudium.board.service;
+
+import com.threeping.mudium.board.dto.BoardDetailDTO;
+import com.threeping.mudium.board.dto.BoardListDTO;
+import com.threeping.mudium.common.exception.CommonException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class BoardServiceImplTests {
+
+    private final BoardService boardService;
+
+    @Autowired
+    BoardServiceImplTests(BoardService boardService){
+        this.boardService = boardService;
+    }
+
+    @DisplayName("게시글 리스트를 페이지로 조회한다.")
+    @Test
+    void boardPageViewTest(){
+        Pageable pageable = PageRequest.of(9999,10, Sort.by("createdAt").descending());
+
+        Page<BoardListDTO> boardDTOPage = boardService.viewBoardList(pageable);
+
+        assertNotNull(boardDTOPage, "조회된 페이지는 null이 아니다.");
+        assertTrue(boardDTOPage.hasContent(), "조회된 페이지는 내용이 있다.");
+        assertEquals(10, boardDTOPage.getSize(), "페이지 크기는 10이다.");
+
+    }
+
+    @DisplayName("게시글 상세 정보를 조회한다.")
+    @Test
+    void boardDetailViewTest(){
+        Long boardId = 1L;
+        Long invalidBoardId = -1L;
+
+        BoardDetailDTO firstBoardDetail = boardService.viewBoard(boardId);
+
+        assertNotNull(firstBoardDetail,"조회된 게시글은 null이 아니다.");
+        assertEquals(boardId,firstBoardDetail.getId(),"조회된 게시글 ID는 요청된 ID와 일치한다.");
+        Exception exception = assertThrows(CommonException.class,
+                ()->{boardService.viewBoard(invalidBoardId);});
+        assertEquals("잘못된 자유게시글 번호입니다.",exception.getMessage());
+
+    }
+
+}


### PR DESCRIPTION
pageable을 이용한 게시글 리스트 조회 및 게시글 상세 조회 기능 추가

---
name: 자유게시글 조회 기능 추가
about: 
1) Pageable을 이용한 게시글 리스트 조회
2) 게시글 아이디를 이용해 게시글 상세 정보 조회
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 테스트 코드 수정이 필요한 부분이 있다면 지적 부탁드립니다!!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/3b2caa98-e4d7-47ab-9965-5d491b6305a4)


## 테스트 계획 또는 완료 사항
- [ ] 서비스 메서드 테스트 완료
- [ ] 테스트항목 2
