### PR TITLE
Feature/musical

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/MudiumApplication.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/MudiumApplication.java
@@ -3,9 +3,11 @@ package com.threeping.mudium;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /* 설명. security ON/OFF */
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
+@EnableScheduling
 //@SpringBootApplication
 public class MudiumApplication {
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -56,7 +56,13 @@ public enum ErrorCode {
 
     //500
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
-    JAXB_CONTEXT_ERROR(50011, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB CONTEXT 생성에 실패했습니다.");
+
+
+    // Musical
+    JAXB_CONTEXT_ERROR(50011, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB CONTEXT 생성에 실패했습니다."),
+    API_LIST_BAD_REQUEST(40011, HttpStatus.BAD_REQUEST, "공연리스트 API 통신에 실패했습니다."),
+    API_DETAIL_BAD_REQUEST(40012, HttpStatus.BAD_REQUEST, "상세정보 API 통신에 실패했습니다."),
+    ITEM_PROCESSING_ERROR(50012, HttpStatus.INTERNAL_SERVER_ERROR, "뮤지컬 정보 혹은 공연 정보 저장에 실패했습니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -55,7 +55,8 @@ public enum ErrorCode {
             , "이메일 인증이 안된 이메일입니다. 이메일 인증을 완료해주세요."),
 
     //500
-    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다");
+    INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
+    JAXB_CONTEXT_ERROR(50011, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB CONTEXT 생성에 실패했습니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/MUDIUM/src/main/java/com/threeping/mudium/config/RestTemplateConfig.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.threeping.mudium.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
@@ -16,7 +16,7 @@ public class Musical {
     @Column(name = "musical_info_id")
     private Long musicalId;
 
-    @Column(name = "musical_name")
+    @Column(name = "title")
     private String title;
 
     @Column(name = "rating")

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
@@ -8,29 +8,26 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-@Entity
-public class MusicalInfo {
+@Entity(name = "TBL_MUSICAL_INFO")
+public class Musical {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "musical_id")
+    @Column(name = "musical_info_id")
     private Long musicalId;
 
     @Column(name = "musical_name")
     private String title;
 
-    @Column(name = "musical_averagescope")
-    private double averageScope;
+    @Column(name = "rating")
+    private String rating;
 
-    @Column(name = "musical_grade")
-    private String grade;
-
-    @Column(name = "musical_reviewvideo")
+    @Column(name = "review_video")
     private String reviewVideo;
 
-    @Column(name = "musical_poster")
+    @Column(name = "image_url")
     private String poster;
 
-    @Column(name = "musical_viewcount")
+    @Column(name = "view_count")
     private int viewCount;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
@@ -1,0 +1,36 @@
+package com.threeping.mudium.musical.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+public class MusicalInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "musical_id")
+    private Long musicalId;
+
+    @Column(name = "musical_name")
+    private String title;
+
+    @Column(name = "musical_averagescope")
+    private double averageScope;
+
+    @Column(name = "musical_grade")
+    private String grade;
+
+    @Column(name = "musical_reviewvideo")
+    private String reviewVideo;
+
+    @Column(name = "musical_poster")
+    private String poster;
+
+    @Column(name = "musical_viewcount")
+    private int viewCount;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
@@ -1,0 +1,2 @@
+package com.threeping.mudium.musical.controller;public class MusicalController {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
@@ -1,2 +1,20 @@
-package com.threeping.mudium.musical.controller;public class MusicalController {
+package com.threeping.mudium.musical.controller;
+
+import com.threeping.mudium.musical.service.MusicalService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("/musical")
+@Slf4j
+public class MusicalController {
+
+    private final MusicalService musicalService;
+
+    @Autowired
+    public MusicalController(MusicalService musicalService) {
+        this.musicalService = musicalService;
+    }
+
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
@@ -3,6 +3,7 @@ package com.threeping.mudium.musical.controller;
 import com.threeping.mudium.musical.service.MusicalService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/musical")

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalItem.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalItem.java
@@ -6,11 +6,13 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 @XmlRootElement(name = "db")
 @XmlAccessorType(XmlAccessType.FIELD)
 @Getter
 @Setter
+@ToString
 public class MusicalItem {
 
     @XmlElement(name = "mt20id")
@@ -19,6 +21,7 @@ public class MusicalItem {
     @XmlElement(name = "prfnm")
     private String title;
 
-    @XmlElement(name = "poster")
-    private String poster;
+    @XmlElement(name = "area")
+    private String area;
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalItem.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalItem.java
@@ -1,0 +1,24 @@
+package com.threeping.mudium.musical.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.Setter;
+
+@XmlRootElement(name = "db")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public class MusicalItem {
+
+    @XmlElement(name = "mt20id")
+    private String externalId;
+
+    @XmlElement(name = "prfnm")
+    private String title;
+
+    @XmlElement(name = "poster")
+    private String poster;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalListResponse.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalListResponse.java
@@ -1,0 +1,25 @@
+package com.threeping.mudium.musical.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.util.Collections;
+import java.util.List;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "dbs")
+public class MusicalListResponse {
+
+    @XmlElement(name = "db")
+    private List<MusicalItem> musicalItems;
+
+    public List<MusicalItem> getMusicalItems() {
+        return musicalItems != null ? musicalItems : Collections.emptyList();
+    }
+
+    public void setMusicalItems(List<MusicalItem> musicalItems) {
+        this.musicalItems = musicalItems;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
@@ -1,0 +1,2 @@
+package com.threeping.mudium.musical.repository;public interface MusicalRepository {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
@@ -1,2 +1,7 @@
-package com.threeping.mudium.musical.repository;public interface MusicalRepository {
+package com.threeping.mudium.musical.repository;
+
+import com.threeping.mudium.musical.aggregate.Musical;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MusicalRepository extends JpaRepository<Musical, Long> {
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
@@ -2,6 +2,12 @@ package com.threeping.mudium.musical.repository;
 
 import com.threeping.mudium.musical.aggregate.Musical;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
+    @Query(value = "SELECT * FROM TBL_MUSICAL_INFO m WHERE m.title = :title", nativeQuery = true)
+    Optional<Musical> findMusicalByExactTitle(@Param("title") String title);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIService.java
@@ -1,4 +1,5 @@
 package com.threeping.mudium.musical.service;
 
 public interface APIService {
+    public void updateMusicalData();
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIService.java
@@ -1,4 +1,4 @@
 package com.threeping.mudium.musical.service;
 
-public interface MusicalService {
+public interface APIService {
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
@@ -3,5 +3,7 @@ package com.threeping.mudium.musical.service;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MusicalServiceImpl implements MusicalService {
+public class APIServiceImpl implements APIService {
+
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
@@ -1,9 +1,120 @@
 package com.threeping.mudium.musical.service;
 
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.musical.dto.MusicalItem;
+import com.threeping.mudium.musical.repository.MusicalRepository;
+import com.threeping.mudium.performance.aggregate.Performance;
+import com.threeping.mudium.performance.dto.PerformanceItem;
+import com.threeping.mudium.performance.repository.PerformanceRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
 
 @Service
+@Slf4j
 public class APIServiceImpl implements APIService {
 
+    private final MusicalRepository musicalRepository;
+    private final PerformanceRepository performanceRepository;
+    private final MusicalAPIClient musicalAPIClient;
 
+    public APIServiceImpl(MusicalRepository musicalRepository, PerformanceRepository performanceRepository,
+                          MusicalAPIClient musicalAPIClient) {
+        this.musicalRepository = musicalRepository;
+        this.performanceRepository = performanceRepository;
+        this.musicalAPIClient = musicalAPIClient;
+    }
+
+//    @Scheduled(cron = "0 0 1 * * ?")
+    @Scheduled(initialDelay = 5000, fixedDelay = 300000000)
+    @Transactional
+    @Override
+    public void updateMusicalData() {
+        try {
+            List<MusicalItem> musicalItems = musicalAPIClient.fetchMusicalList();
+            for (MusicalItem item : musicalItems) {
+                processMusicalItem(item);
+            }
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.API_LIST_BAD_REQUEST);
+        }
+    }
+
+    private void processMusicalItem(MusicalItem item) {
+        try {
+            String OriginTitle = parseTitle(item.getTitle());
+            log.info("제목 파싱 확인: {}", OriginTitle);
+            Musical musical = getOrCreatedMusical(OriginTitle);
+            PerformanceItem performanceItem =
+                    musicalAPIClient.fetchPerformanceDetail(item.getExternalId());
+            updateMusicalInfo(musical, performanceItem);
+            log.info("업데이트된 뮤지컬 정보 확인: " + musical);
+            Performance performance = getOrCreatedPerformance(musical.getMusicalId(), item.getArea());
+            updatePerformance(performance, performanceItem);
+            log.info("업데이트된 공연 정보 확인: " + performance);
+
+            musicalRepository.save(musical);
+            performanceRepository.save(performance);
+        } catch (Exception e) {
+            log.info("저장 실패한 item의 외부 externalId: " + item.getExternalId());
+            log.info("저장에 실패한 item의 타이틀: " + item.getTitle());
+            throw new CommonException(ErrorCode.ITEM_PROCESSING_ERROR);
+        }
+    }
+
+    private void updatePerformance(Performance performance, PerformanceItem performanceItem) {
+        performance.setActorList(performanceItem.getActorList());
+        performance.setTheater(performanceItem.getTheater());
+        performance.setEndDate(timeStampConverter(performanceItem.getEndDate()));
+        performance.setStartDate(timeStampConverter(performanceItem.getStartDate()));
+        performance.setRunTime(performanceItem.getRunTime());
+    }
+
+    private void updateMusicalInfo(Musical musical, PerformanceItem performanceItem) {
+        musical.setRating(performanceItem.getAge());
+        if(musical.getPoster() == null)
+        musical.setPoster(performanceItem.getPoster());
+    }
+
+    private Performance getOrCreatedPerformance(Long musicalId, String area) {
+        return performanceRepository.findPerformanceByMusicalIdAndRegion(musicalId, area)
+                .orElseGet(() -> {
+                    Performance performance = new Performance();
+                    performance.setMusicalId(musicalId);
+                    performance.setRegion(area);
+                    return performance;
+                });
+    }
+
+    private Musical getOrCreatedMusical(String originTitle) {
+        return musicalRepository.findMusicalByExactTitle(originTitle).orElseGet(() -> {
+           Musical musical = new Musical();
+           musical.setTitle(originTitle);
+           musicalRepository.save(musical);
+           return musical;
+        });
+    }
+
+    private String parseTitle(String title) {
+        return title.replaceAll("\\[.*?\\]", "").trim();
+    }
+
+    private Timestamp timeStampConverter(String Date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        LocalDate localDate = LocalDate.parse(Date, formatter);
+
+        LocalDateTime localDateTime = localDate.atStartOfDay();
+
+        return Timestamp.valueOf(localDateTime);
+    }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
@@ -1,0 +1,33 @@
+package com.threeping.mudium.musical.service;
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.dto.MusicalItem;
+import com.threeping.mudium.musical.dto.MusicalListResponse;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+import java.io.StringReader;
+
+public class JAXBManager {
+    private static final JAXBManager INSTANCE = new JAXBManager();
+    private final JAXBContext jaxbContext;
+
+    private JAXBManager() {
+        try {
+            this.jaxbContext = JAXBContext.newInstance(MusicalListResponse.class, MusicalItem.class);
+        } catch (JAXBException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+    }
+
+    public static JAXBManager getInstance() {
+        return INSTANCE;
+    }
+
+    public <T> T unmarshal(String xml, Class<T> clazz) throws JAXBException {
+        Unmarshaller unmarshaller = this.jaxbContext.createUnmarshaller();
+        return clazz.cast(unmarshaller.unmarshal(new StringReader(xml)));
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
@@ -4,19 +4,33 @@ import com.threeping.mudium.common.exception.CommonException;
 import com.threeping.mudium.common.exception.ErrorCode;
 import com.threeping.mudium.musical.dto.MusicalItem;
 import com.threeping.mudium.musical.dto.MusicalListResponse;
+import com.threeping.mudium.performance.dto.PerformanceItem;
+import com.threeping.mudium.performance.dto.PerformanceResponse;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.StringReader;
 
+import static jakarta.xml.bind.JAXB.unmarshal;
+
+@Slf4j
 public class JAXBManager {
     private static final JAXBManager INSTANCE = new JAXBManager();
-    private final JAXBContext jaxbContext;
+    private final JAXBContext musicalContext;
+    private final JAXBContext performanceContext;
 
     private JAXBManager() {
         try {
-            this.jaxbContext = JAXBContext.newInstance(MusicalListResponse.class, MusicalItem.class);
+            this.musicalContext = JAXBContext.newInstance(
+                    MusicalListResponse.class,
+                    MusicalItem.class);
+            log.info("JAXBManager MusicalList Mapping Context 싱글톤 객체 생성 성공");
+            this.performanceContext = JAXBContext.newInstance(
+                    PerformanceResponse.class,
+                    PerformanceItem.class);
+            log.info("JAXBManager Performance Mapping Context 싱글톤 객체 생성 성공");
         } catch (JAXBException e) {
             throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
         }
@@ -26,8 +40,18 @@ public class JAXBManager {
         return INSTANCE;
     }
 
-    public <T> T unmarshal(String xml, Class<T> clazz) throws JAXBException {
-        Unmarshaller unmarshaller = this.jaxbContext.createUnmarshaller();
+    // 흐름: 공연 리스트 매핑 객체와 공연 상세 정보 매핑 객체에 대한 context가 다르므로 unmarshal method에
+    // unmarshaller 객체를 생성할 context도 넘겨줘서 각 각 고유 unmarshaller가 생기도록 함
+    public <T> T unmarshalMusical(String xml, Class<T> clazz) throws JAXBException {
+        return unmarshal(xml, clazz, musicalContext);
+    }
+
+    public <T> T unmarshalPerformance(String xml, Class<T> clazz) throws JAXBException {
+        return unmarshal(xml, clazz, performanceContext);
+    }
+
+    private <T> T unmarshal(String xml, Class<T> clazz, JAXBContext context) throws JAXBException {
+        Unmarshaller unmarshaller = context.createUnmarshaller();
         return clazz.cast(unmarshaller.unmarshal(new StringReader(xml)));
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
@@ -1,0 +1,80 @@
+package com.threeping.mudium.musical.service;
+
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.dto.MusicalItem;
+import com.threeping.mudium.musical.dto.MusicalListResponse;
+import jakarta.xml.bind.JAXBException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MusicalAPIClient {
+
+    @Value("${kopis.api.key}")
+    private String apiKey;
+
+    @Value("${kopis.api.url}")
+    private String baseUrl;
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public MusicalAPIClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<MusicalItem> fetchMusicalList() {
+        String startDate = "20220101";
+        String endDate = "20240930";
+        int cPage = 1;
+        List<MusicalItem> allMusicals = new ArrayList<>();
+
+        while(true) {
+            String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                    .queryParam("service", apiKey)
+                    .queryParam("stdate", startDate)
+                    .queryParam("eddate", endDate)
+                    .queryParam("cpage", cPage + "")
+                    .queryParam("rows", "100")
+                    .queryParam("shcate", "GGGA")
+                    .toUriString();
+
+            String response = restTemplate.getForObject(url, String.class);
+            MusicalListResponse parsedResponse = parseXmlResponse(response);
+            List<MusicalItem> musicalItems = parsedResponse.getMusicalItems();
+
+            if (musicalItems == null || musicalItems.isEmpty()) {
+                break; // 결과가 없으면 루프 종료
+            }
+            allMusicals.addAll(musicalItems);
+            cPage++;
+        }
+        return allMusicals;
+    }
+
+//    public
+
+    private MusicalListResponse parseXmlResponse(String response) {
+        try {
+            return JAXBManager.getInstance().unmarshal(response, MusicalListResponse.class);
+        } catch (JAXBException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+    }
+
+    private MusicalItem parseXmlItem(String response) {
+        try {
+            return JAXBManager.getInstance().unmarshal(response, MusicalItem.class);
+        } catch (JAXBException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
@@ -1,0 +1,2 @@
+package com.threeping.mudium.musical.service;public interface MusicalService {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
@@ -1,0 +1,2 @@
+package com.threeping.mudium.musical.service;public class MusicalServiceImpl {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/Performance.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/Performance.java
@@ -1,0 +1,41 @@
+package com.threeping.mudium.performance.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity(name = "TBL_PERFORMANCE")
+public class Performance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "performance_id")
+    private Long performanceId;
+
+    @Column(name = "region")
+    private String region;
+
+    @Column(name = "start_date")
+    private Timestamp startDate;
+
+    @Column(name = "end_date")
+    private Timestamp endDate;
+
+    @Column(name = "runtime")
+    private String runTime;
+
+    @Column(name = "theater")
+    private String theater;
+
+    @Column(name = "actor_list")
+    private String actorList;
+
+    @Column(name = "musical_info_id")
+    private Long musicalId;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceItem.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceItem.java
@@ -1,0 +1,42 @@
+package com.threeping.mudium.performance.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@XmlRootElement(name = "db")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+@ToString
+public class PerformanceItem {
+
+    @XmlElement(name = "prfpdfrom")
+    private String startDate;
+
+    @XmlElement(name = "prfpdto")
+    private String endDate;
+
+    @XmlElement(name = "fcltynm")
+    private String theater;
+
+    @XmlElement(name = "area")
+    private String region;
+
+    @XmlElement(name = "prfcast")
+    private String actorList;
+
+    @XmlElement(name = "prfruntime")
+    private String runTime;
+
+    @XmlElement(name = "prfage")
+    private String age;
+
+    @XmlElement(name = "poster")
+    private String poster;
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceResponse.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceResponse.java
@@ -1,0 +1,22 @@
+package com.threeping.mudium.performance.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "dbs")
+public class PerformanceResponse {
+
+    @XmlElement(name = "db")
+    PerformanceItem performanceItem;
+
+    public PerformanceItem getPerformanceItem() {
+        return performanceItem;
+    }
+
+    public void setPerformanceItem(PerformanceItem performanceItem) {
+        this.performanceItem = performanceItem;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
@@ -1,0 +1,11 @@
+package com.threeping.mudium.performance.repository;
+
+import com.threeping.mudium.performance.aggregate.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+    Optional<Performance> findByMusicalId(long musicalId);
+    Optional<Performance> findPerformanceByMusicalIdAndRegion(Long musicalId, String region);
+}


### PR DESCRIPTION
---
name: 뮤지컬 엔티티 및 공연 정보 엔티티 개발
about: kopis api와 통신을 통해 xml로 넘어온 뮤지컬 정보를 공연 정보와 뮤지컬 정보로 저장하도록 구현했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- JABX Context로 xml을 자바 객체로 매핑할 때, 서로 다른 객체라면 별도의 context를 생성해줄 것
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- api 요청을 하기위한 url과 api key가 yml 파일에 들어갑니다! 디스코드에 올려 놨으니 꼭 바꿔주세요!
- 뮤지컬 고유 ErrorCode를 추가했습니다. 풀을 할 때 overwritten되지 않도록 유의해 주세요!
- db musical_info 테이블의 not null 조건이 변경되었습니다(title과 id 빼고 nullable하게 바뀜) 구동하기 전에 db를 꼭 새로 미셔야 해요!

## 관련 스크린 샷 
<img width="927" alt="image" src="https://github.com/user-attachments/assets/5158661e-8b4b-430e-958c-01968619a119">
고유 ErrorCode 추가

<img width="927" alt="image" src="https://github.com/user-attachments/assets/8f15c21e-3a4a-4f75-b416-eafe499ec14c">
뮤지컬 정보 저장

<img width="996" alt="image" src="https://github.com/user-attachments/assets/b7b2bb2c-29db-42e7-83c9-287c7c62419f">
공연 정보 저장

## 테스트 계획 또는 완료 사항
- [x] Api와 통신해서 db에 실제 뮤지컬 정보를 저장
- [x] Api와 통신해서 db에 실제 공연 정보를 저장
