### PR TITLE
ADD: 뮤지컬 게시판 조회

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -64,7 +64,9 @@ public enum ErrorCode {
     API_LIST_BAD_REQUEST(40011, HttpStatus.BAD_REQUEST, "공연리스트 API 통신에 실패했습니다."),
     API_DETAIL_BAD_REQUEST(40012, HttpStatus.BAD_REQUEST, "상세정보 API 통신에 실패했습니다."),
     ITEM_PROCESSING_ERROR(50012, HttpStatus.INTERNAL_SERVER_ERROR, "뮤지컬 정보 혹은 공연 정보 저장에 실패했습니다."),
-    INVALID_MUSICAL_ID(40013, HttpStatus.BAD_REQUEST, "잘못된 뮤지컬 번호입니다.");
+    INVALID_MUSICAL_ID(40013, HttpStatus.BAD_REQUEST, "잘못된 뮤지컬 번호입니다."),
+    INVALID_MUSICAL_BOARD_ID(40014, HttpStatus.BAD_REQUEST, "잘못된 뮤지컬 게시글 번호입니다."),
+    NOT_FOUND_MUSICAL_BOARD(40411, HttpStatus.NOT_FOUND, "존재하지 않는 뮤지컬 게시글 번호입니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-@RestController("/api/musical")
+@RestController("/api/musicals")
 @Slf4j
 public class MusicalController {
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
@@ -1,7 +1,11 @@
 package com.threeping.mudium.musical.service;
 
+import com.threeping.mudium.musical.aggregate.Musical;
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
+
 
 public interface MusicalService {
     MusicalTotalDTO findMusicalDetail(Long musicId);
+
+    Musical findMusicalByMusicalId(Long musicalId);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+
 @Service
 public class MusicalServiceImpl implements MusicalService {
 
@@ -20,7 +21,8 @@ public class MusicalServiceImpl implements MusicalService {
     private final PerformanceService performanceService;
 
     @Autowired
-    public MusicalServiceImpl(MusicalRepository musicalRepository, PerformanceService performanceService) {
+    public MusicalServiceImpl(MusicalRepository musicalRepository,
+                              PerformanceService performanceService) {
         this.musicalRepository = musicalRepository;
         this.performanceService = performanceService;
     }
@@ -38,5 +40,13 @@ public class MusicalServiceImpl implements MusicalService {
         totalDTO.setPerformanceList(performanceList);
 
         return totalDTO;
+    }
+
+    @Override
+    @Transactional
+    public Musical findMusicalByMusicalId(Long musicalId) {
+        Musical musical = musicalRepository.findMusicalByMusicalId(musicalId)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_ID));
+        return musical;
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/ActiveStatus.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/ActiveStatus.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.musicalboard.aggregate;
+
+public enum ActiveStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/MusicalPost.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/MusicalPost.java
@@ -1,0 +1,52 @@
+package com.threeping.mudium.musicalboard.aggregate;
+
+import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "TBL_MUSICAL_BOARD")
+public class MusicalPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "musical_board_id")
+    private Long musicalPostId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "view_count")
+    private Long viewCount;
+
+    @Column(name = "like")
+    private Long like;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "active_status", nullable = false)
+    private ActiveStatus activeStatus;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private UserEntity userEntity;
+
+    @JoinColumn(name = "musical_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Musical musical;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/controller/MusicalBoardController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/controller/MusicalBoardController.java
@@ -1,0 +1,53 @@
+package com.threeping.mudium.musicalboard.controller;
+
+import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.musicalboard.dto.MusicalPostDTO;
+import com.threeping.mudium.musicalboard.dto.MusicalPostListDTO;
+import com.threeping.mudium.musicalboard.service.MusicalBoardService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController("/api/musical-board")
+@Slf4j
+public class MusicalBoardController {
+
+    private final MusicalBoardService musicalBoardService;
+
+    @Autowired
+    public MusicalBoardController(MusicalBoardService musicalBoardService) {
+        this.musicalBoardService = musicalBoardService;
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseDTO<?> findMusicalBoard(@PathVariable Long boardId) {
+        List<MusicalPostListDTO> postListDTOlist = musicalBoardService.findAllPost(boardId);
+
+        ResponseDTO<List<MusicalPostListDTO>> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(postListDTOlist);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        responseDTO.setSuccess(true);
+        return responseDTO;
+    }
+
+    // 글 조회는 글의 PK만 받도록한다.
+    //단일 책임 원칙 (Single Responsibility Principle):
+    //각 엔티티는 고유한 식별자를 가져야 한다. 게시글 PK가 있다면, 이것만으로도 unique한 게시글을 식별할 수 있어야 한다.
+    //데이터베이스 설계:
+    //일반적으로 게시글 테이블은 이미 뮤지컬 ID를 외래 키로 가지고 있다. 따라서 게시글 PK만으로도 해당 게시글이 어떤 뮤지컬에 속하는지 알 수 있다
+    @GetMapping("/{musicalPostId}")
+    public ResponseDTO<?> findMusicalPost(@PathVariable Long musicalPostId) {
+        MusicalPostDTO postDTO = musicalBoardService.findPost(musicalPostId);
+
+        ResponseDTO<MusicalPostDTO> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(postDTO);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        responseDTO.setSuccess(true);
+        return responseDTO;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/dto/MusicalPostDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/dto/MusicalPostDTO.java
@@ -1,0 +1,29 @@
+package com.threeping.mudium.musicalboard.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class MusicalPostDTO {
+
+    private String title;
+
+    private String content;
+
+    private String createdAt;
+
+    private String updatedAt;
+
+    private Long like;
+
+    private Long viewCount;
+
+    private String nickname;
+
+//    private List<MusicalComment> commentList;
+
+//    private List<MusicalReply> replyList;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/dto/MusicalPostListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/dto/MusicalPostListDTO.java
@@ -1,0 +1,25 @@
+package com.threeping.mudium.musicalboard.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class MusicalPostListDTO {
+
+    private Long postId;
+
+    private String title;
+
+    private String writer;
+
+    private Long comment;
+
+    private Long like;
+
+    private String viewCount;
+
+    private String createdAt;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/repository/MusicalBoardRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/repository/MusicalBoardRepository.java
@@ -1,0 +1,18 @@
+package com.threeping.mudium.musicalboard.repository;
+
+import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.musicalboard.aggregate.ActiveStatus;
+import com.threeping.mudium.musicalboard.aggregate.MusicalPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MusicalBoardRepository extends JpaRepository<MusicalPost, Long> {
+
+    List<MusicalPost> findAllByMusicalAndActiveStatus(Musical musical, ActiveStatus activeStatus);
+
+    Optional<MusicalPost> findMusicalPostsByMusicalPostId(Long musicalPostId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardService.java
@@ -1,0 +1,13 @@
+package com.threeping.mudium.musicalboard.service;
+
+import com.threeping.mudium.musicalboard.dto.MusicalPostDTO;
+import com.threeping.mudium.musicalboard.dto.MusicalPostListDTO;
+
+import java.util.List;
+
+public interface MusicalBoardService {
+
+    List<MusicalPostListDTO> findAllPost(Long musicalId);
+
+    MusicalPostDTO findPost(Long musicalPostId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImpl.java
@@ -1,0 +1,93 @@
+package com.threeping.mudium.musicalboard.service;
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.musical.service.MusicalService;
+import com.threeping.mudium.musicalboard.aggregate.ActiveStatus;
+import com.threeping.mudium.musicalboard.aggregate.MusicalPost;
+import com.threeping.mudium.musicalboard.dto.MusicalPostDTO;
+import com.threeping.mudium.musicalboard.dto.MusicalPostListDTO;
+import com.threeping.mudium.musicalboard.repository.MusicalBoardRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@Transactional
+public class MusicalBoardServiceImpl implements MusicalBoardService {
+
+    private final MusicalBoardRepository musicalBoardRepository;
+    private final MusicalService musicalService;
+
+    @Autowired
+    public MusicalBoardServiceImpl(MusicalBoardRepository musicalBoardRepository, MusicalService musicalService) {
+        this.musicalBoardRepository = musicalBoardRepository;
+        this.musicalService = musicalService;
+    }
+
+    @Override
+    public List<MusicalPostListDTO> findAllPost(Long musicalId) {
+        Musical musical = musicalService.findMusicalByMusicalId(musicalId);
+        List<MusicalPost> postList = musicalBoardRepository.findAllByMusicalAndActiveStatus(musical, ActiveStatus.ACTIVE);
+
+        List<MusicalPostListDTO> postDTOList = postList.stream()
+                .map(musicalPost -> {
+                    MusicalPostListDTO postDTO = new MusicalPostListDTO();
+                    postDTO.setPostId(musicalPost.getMusicalPostId());
+                    postDTO.setTitle(musicalPost.getTitle());
+                    postDTO.setLike(musicalPost.getLike());
+                    postDTO.setViewCount(viewConverter(musicalPost.getViewCount()));
+                    postDTO.setCreatedAt(timeConverter(musicalPost.getCreatedAt()));
+                    postDTO.setWriter(musicalPost.getUserEntity().getNickname());
+                    return postDTO;
+                }).collect(Collectors.toList());
+
+        return postDTOList;
+    }
+
+    @Override
+    public MusicalPostDTO findPost(Long musicalPostId) {
+        MusicalPost musicalPost = musicalBoardRepository.findMusicalPostsByMusicalPostId(musicalPostId)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_BOARD_ID));
+
+        if(musicalPost.getActiveStatus() == ActiveStatus.INACTIVE) {
+            throw new CommonException(ErrorCode.NOT_FOUND_MUSICAL_BOARD);
+        }
+
+        MusicalPostDTO postDTO = new MusicalPostDTO();
+        postDTO.setTitle(musicalPost.getTitle());
+        postDTO.setContent(musicalPost.getContent());
+        postDTO.setLike(musicalPost.getLike());
+        postDTO.setCreatedAt(detailTimeConverter(musicalPost.getCreatedAt()));
+        postDTO.setUpdatedAt(detailTimeConverter(musicalPost.getUpdatedAt()));
+        postDTO.setNickname(musicalPost.getUserEntity().getNickname());
+        postDTO.setViewCount(musicalPost.getViewCount());
+
+        return postDTO;
+    }
+
+    private String viewConverter(Long viewCount) {
+        if(viewCount > 10000) {
+            return viewCount / 10000 + "만";
+        }
+        return viewCount + "";
+    }
+
+    private String timeConverter(Timestamp date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        return sdf.format(date);
+    }
+
+    private String detailTimeConverter(Timestamp date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy년 MM월 dd일 HH시 mm분 ss초");
+        return sdf.format(date);
+    }
+}

--- a/MUDIUM/src/test/java/com/threeping/mudium/musical/service/MusicalServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/musical/service/MusicalServiceImplTests.java
@@ -1,10 +1,13 @@
 package com.threeping.mudium.musical.service;
 
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
+import com.threeping.mudium.performance.dto.PerformanceDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,8 +29,10 @@ class MusicalServiceImplTests {
 
         // when
         MusicalTotalDTO musicalDetail = musicalService.findMusicalDetail(musicId);
+        List<PerformanceDTO> list = musicalDetail.getPerformanceList();
 
         // then
         assertNotNull(musicalDetail, "조회된 뮤지컬 상세 정보는 null이 아니다.");
+        assertFalse(list.isEmpty(), "조회된 뮤지컬의 공연 정보는 비어있지 않다.");
     }
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImplTests.java
@@ -1,0 +1,49 @@
+package com.threeping.mudium.musicalboard.service;
+
+import com.threeping.mudium.musicalboard.dto.MusicalPostDTO;
+import com.threeping.mudium.musicalboard.dto.MusicalPostListDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+
+@SpringBootTest
+class MusicalBoardServiceImplTests {
+
+    private final MusicalBoardService musicalBoardService;
+
+    @Autowired
+    public MusicalBoardServiceImplTests(MusicalBoardService musicalBoardService) {
+        this.musicalBoardService = musicalBoardService;
+    }
+
+    @DisplayName("특정 뮤지컬 게시글 전부 조회한다.")
+    @Test
+    void findAllPosts() {
+        // given
+        Long musicalBoardId = 1L;
+
+        // when
+        List<MusicalPostListDTO> postList = musicalBoardService.findAllPost(musicalBoardId);
+
+        // then
+        assertNotNull(postList, "게시글 리스트는 null이 아니다.");
+        assertFalse(postList.isEmpty(), "게시글 리스트는 비어있지 않다.");
+    }
+
+    @DisplayName("특정 뮤지컬 게시판의 특정 게시글을 조회한다.")
+    @Test
+    void findPostById() {
+        // given
+        Long musicalBoardId = 31L;
+
+        // when
+        MusicalPostDTO postDTO = musicalBoardService.findPost(musicalBoardId);
+
+        // then
+        assertNotNull(postDTO, "조회된 게시글은 null이 아니다.");
+    }
+}


### PR DESCRIPTION
---
name: 뮤지컬 게시판 조회
about: 뮤지컬 번호로 특정 게시판을 조회하고, 특정 게시글 번호로 게시글을 상세 조회하는 기능을 개발했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 


## 관련 스크린 샷
뮤지컬 번호로 해당 게시판의 모든 글(inactive 상태 제외) 조회
<img width="769" alt="스크린샷 2024-10-13 오후 8 40 04" src="https://github.com/user-attachments/assets/5954a9ee-5a80-46b9-91fe-2bac33265372">

게시글 번호로 글 상세조회
<img width="769" alt="image" src="https://github.com/user-attachments/assets/e2473e20-b1f1-4569-a941-ea4bd7a46c00">
 

## 테스트 계획 또는 완료 사항
- [x] 뮤지컬 번호로 해당 게시판의 모든 글 조회
- [x] 뮤지컬 번호로 특정 게시글 내용 상세 조회
