### PR TITLE
ADD: 뮤지컬 검색을 통한 동적 조회, 뮤지컬 조회 시, 평균 별점 조회

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -66,6 +66,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(4041001, HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
     MUSICAL_NOT_FOUND(4041002, HttpStatus.NOT_FOUND, "뮤지컬이 존재하지 않습니다."),
 
+    //
+    SCOPE_NOT_FOUND(4041003, HttpStatus.NOT_FOUND, "별점이 존재하지 않습니다."),
+
     // Musical
     JAXB_CONTEXT_ERROR(50011, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB CONTEXT 생성에 실패했습니다."),
     API_LIST_BAD_REQUEST(40011, HttpStatus.BAD_REQUEST, "공연리스트 API 통신에 실패했습니다."),

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/aggregate/Musical.java
@@ -8,7 +8,8 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-@Entity(name = "TBL_MUSICAL_INFO")
+@Entity(name = "MusicalEntity")
+@Table(name = "TBL_MUSICAL_INFO")
 public class Musical {
 
     @Id
@@ -30,4 +31,10 @@ public class Musical {
 
     @Column(name = "view_count")
     private int viewCount;
+
+    @Column(name = "production")
+    private String production;
+
+    @Column(name = "synopsys")
+    private String synopsys;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/controller/MusicalController.java
@@ -1,16 +1,20 @@
 package com.threeping.mudium.musical.controller;
 
 import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.musical.dto.MusicalListDTO;
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
 import com.threeping.mudium.musical.service.MusicalService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-@RestController("/api/musicals")
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/musical")
 @Slf4j
 public class MusicalController {
 
@@ -22,6 +26,18 @@ public class MusicalController {
     }
 
 
+    @GetMapping("")
+    public ResponseDTO<?> findAllMusical(@RequestParam(required = false) String title, Pageable pageable) {
+        Page<MusicalListDTO> musicalPage = musicalService.findByName(title, pageable);
+
+        ResponseDTO<Page<MusicalListDTO>> responseDTO = new ResponseDTO<>();
+        responseDTO.setSuccess(true);
+        responseDTO.setData(musicalPage);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+
+        return responseDTO;
+    }
+
     @GetMapping("/{musicalId}")
     public ResponseDTO<?> findMusical(@PathVariable("musicalId") Long musicalId) {
         MusicalTotalDTO totalDTO = musicalService.findMusicalDetail(musicalId);
@@ -30,6 +46,7 @@ public class MusicalController {
         responseDTO.setData(totalDTO);
         responseDTO.setHttpStatus(HttpStatus.OK);
         responseDTO.setSuccess(true);
+
         return responseDTO;
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalListDTO.java
@@ -1,0 +1,19 @@
+package com.threeping.mudium.musical.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class MusicalListDTO {
+
+    private Long musicalId;
+
+    private String title;
+
+    private String poster;
+
+    private String averageScope;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalTotalDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalTotalDTO.java
@@ -15,7 +15,7 @@ public class MusicalTotalDTO {
 
     private String poster;
 
-//    private String scope; 별점이 추가되면 '평균 별점'을 계산해서 넣을 예정
+    private String scope;
 
     private String rating;
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/repository/MusicalRepository.java
@@ -1,14 +1,18 @@
 package com.threeping.mudium.musical.repository;
 
 import com.threeping.mudium.musical.aggregate.Musical;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     @Query(value = "SELECT * FROM TBL_MUSICAL_INFO m WHERE m.title = :title", nativeQuery = true)
     Optional<Musical> findMusicalByExactTitle(@Param("title") String title);
     Optional<Musical> findMusicalByMusicalId(Long musicalId);
+    Page<Musical> findByTitleContainingIgnoreCase(String title, Pageable pageable);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/APIServiceImpl.java
@@ -16,6 +16,7 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -56,6 +57,7 @@ public class APIServiceImpl implements APIService {
             Musical musical = getOrCreatedMusical(OriginTitle);
             PerformanceItem performanceItem =
                     musicalAPIClient.fetchPerformanceDetail(item.getExternalId());
+            log.info("external Id: " + item.getExternalId());
             updateMusicalInfo(musical, performanceItem);
             log.info("업데이트된 뮤지컬 정보 확인: " + musical);
             Performance performance = getOrCreatedPerformance(musical, item.getArea());
@@ -77,12 +79,15 @@ public class APIServiceImpl implements APIService {
         performance.setEndDate(timeStampConverter(performanceItem.getEndDate()));
         performance.setStartDate(timeStampConverter(performanceItem.getStartDate()));
         performance.setRunTime(performanceItem.getRunTime());
+        performance.setPoster(performanceItem.getPoster());
     }
 
     private void updateMusicalInfo(Musical musical, PerformanceItem performanceItem) {
         musical.setRating(performanceItem.getAge());
         if(musical.getPoster() == null)
-        musical.setPoster(performanceItem.getPoster());
+            musical.setPoster(performanceItem.getPoster());
+        if(musical.getProduction() == null)
+            musical.setProduction(performanceItem.getEntrps());
     }
 
     private Performance getOrCreatedPerformance(Musical musical, String area) {

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
@@ -37,8 +37,7 @@ public class MusicalAPIClient {
     }
 
     public List<MusicalItem> fetchMusicalList() {
-        // test를 위해선 좀 줄입니다
-        String startDate = "20240901";
+        String startDate = "20220101";
         String endDate = "20240930";
         int cPage = 1;
         List<MusicalItem> allMusicals = new ArrayList<>();

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
@@ -1,11 +1,19 @@
 package com.threeping.mudium.musical.service;
 
 import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.musical.dto.MusicalListDTO;
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 
 public interface MusicalService {
     MusicalTotalDTO findMusicalDetail(Long musicId);
 
     Musical findMusicalByMusicalId(Long musicalId);
+
+    Page<MusicalListDTO> findByName(String title,Pageable pageable);
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
@@ -3,32 +3,100 @@ package com.threeping.mudium.musical.service;
 import com.threeping.mudium.common.exception.CommonException;
 import com.threeping.mudium.common.exception.ErrorCode;
 import com.threeping.mudium.musical.aggregate.Musical;
+import com.threeping.mudium.musical.dto.MusicalListDTO;
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
 import com.threeping.mudium.musical.repository.MusicalRepository;
 import com.threeping.mudium.performance.dto.PerformanceDTO;
 import com.threeping.mudium.performance.service.PerformanceService;
+import com.threeping.mudium.scope.service.ScopeService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 @Service
+@Transactional
 public class MusicalServiceImpl implements MusicalService {
 
     private final MusicalRepository musicalRepository;
     private final PerformanceService performanceService;
+    private final ScopeService scopeService;
 
     @Autowired
     public MusicalServiceImpl(MusicalRepository musicalRepository,
-                              PerformanceService performanceService) {
+                              PerformanceService performanceService,
+                              ScopeService scopeService) {
         this.musicalRepository = musicalRepository;
         this.performanceService = performanceService;
+        this.scopeService = scopeService;
     }
 
     @Override
-    @Transactional
+    public Page<MusicalListDTO> findByName(String title, Pageable pageable) {
+
+        // jpa는 페이지 번호를 0부터 시작하기 때문에 0으로 pageNumber 설정
+        int pageNumber = pageable.getPageNumber()<= 1 ? 0 : pageable.getPageNumber() - 1;
+        int pageSize = pageable.getPageSize();
+        Sort sort = Sort.by("viewCount").descending();
+        Pageable musicalPageable = PageRequest.of(pageNumber, pageSize, sort);
+
+        Page<Musical> musicalPage;
+
+        if(title != null && !title.trim().isEmpty()) {
+            // 제목으로 검색
+            musicalPage = musicalRepository.findByTitleContainingIgnoreCase(title, musicalPageable);
+        } else {
+            // 아무것도 입력 안 하면 모두가 가져오기
+            musicalPage = musicalRepository.findAll(musicalPageable);
+        }
+
+        // JPA가 페이징 쿼리를 실행할 때, 기본적으로 두 가지 쿼리를 실행:
+        // a) 요청된 페이지의 데이터를 가져오는 쿼리
+        // b) 전체 데이터의 개수를 세는 카운트 쿼리
+        if(musicalPage.getTotalPages() < pageSize) {
+            Pageable maxPageable = PageRequest.of(musicalPage.getTotalPages() - 1, pageSize, sort);
+            if(title != null && !title.trim().isEmpty()) {
+                musicalPage = musicalRepository.findByTitleContainingIgnoreCase(title, musicalPageable);
+            } else {
+                musicalPage = musicalRepository.findAll(maxPageable);
+            }
+        }
+
+        List<Long> musicalIds = musicalPage.getContent().stream()
+                .map(Musical::getMusicalId)
+                .collect(Collectors.toList());
+
+        Map<Long, String> averageScopes = scopeService.calculateAverageScopeBatch(musicalIds);
+
+        List<MusicalListDTO> dtoList = musicalPage.getContent().stream()
+                .map(musical -> {
+                    MusicalListDTO dto = new MusicalListDTO();
+                    dto.setMusicalId(musical.getMusicalId());
+                    dto.setPoster(musical.getPoster());
+                    dto.setTitle(musical.getTitle());
+                    dto.setAverageScope(averageScopes.get(musical.getMusicalId()));
+                    return dto;
+                }).collect(Collectors.toList());
+        // 전체 데이터셋의 총 항목 수를 나타냄.
+        //이 정보를 통해 Page 객체는 다음과 같은 중요한 메타데이터를 계산 가능:
+        //a) 총 페이지 수 (getTotalPages())
+        //b) 현재 페이지가 첫 페이지인지 (isFirst())
+        //c) 현재 페이지가 마지막 페이지인지 (isLast())
+        //d) 다음 페이지가 있는지 (hasNext())
+        //e) 이전 페이지가 있는지 (hasPrevious())
+        // 위의 정보를 활용해 client는 다음 페이지 버튼을 만들지 말지 같은 걸 구성가능
+        Page<MusicalListDTO> dtoPage = new PageImpl<>(dtoList, pageable, musicalPage.getTotalElements());
+
+        return dtoPage;
+    }
+
+    @Override
     public MusicalTotalDTO findMusicalDetail(Long musicalId) {
         MusicalTotalDTO totalDTO = new MusicalTotalDTO();
         Musical musical = musicalRepository.findMusicalByMusicalId(musicalId)
@@ -38,12 +106,17 @@ public class MusicalServiceImpl implements MusicalService {
         totalDTO.setRating(musical.getRating());
         totalDTO.setPoster(musical.getPoster());
         totalDTO.setPerformanceList(performanceList);
+        List<Long> musicalIds = new ArrayList<>();
+        musicalIds.add(musical.getMusicalId());
+        totalDTO.setScope(scopeService.calculateAverageScopeBatch(musicalIds).get(musicalId));
+        // 조회되면 조회 수 1 증가
+        musical.setViewCount(musical.getViewCount() + 1);
+        musicalRepository.save(musical);
 
         return totalDTO;
     }
 
     @Override
-    @Transactional
     public Musical findMusicalByMusicalId(Long musicalId) {
         Musical musical = musicalRepository.findMusicalByMusicalId(musicalId)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_ID));

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/Performance.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/Performance.java
@@ -37,6 +37,9 @@ public class Performance {
     @Column(name = "actor_list")
     private String actorList;
 
+    @Column(name = "poster")
+    private String poster;
+
     @JoinColumn(name = "musical_info_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Musical musical;

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceItem.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceItem.java
@@ -39,4 +39,7 @@ public class PerformanceItem {
     @XmlElement(name = "poster")
     private String poster;
 
+    @XmlElement(name = "entrpsnm")
+    private String entrps;
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/aggregate/entity/ScopeEntity.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/aggregate/entity/ScopeEntity.java
@@ -1,5 +1,6 @@
 package com.threeping.mudium.scope.aggregate.entity;
 
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -31,4 +32,7 @@ public class ScopeEntity {
 
     @Column(name="updated_at", nullable=true)
     private Timestamp updatedAt;
+
+    @Column(name = "user_nickname", nullable = false)
+    private String userNickname;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/aggregate/entity/ScopeId.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/aggregate/entity/ScopeId.java
@@ -4,12 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public class ScopeId {
+public class ScopeId implements Serializable {
 
     private Long musicalId;
     private Long userId;

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/controller/ScopeController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/controller/ScopeController.java
@@ -2,6 +2,7 @@ package com.threeping.mudium.scope.controller;
 
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
 import com.threeping.mudium.scope.service.ScopeService;
+import com.threeping.mudium.scope.vo.ScopeVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,10 +22,8 @@ public class ScopeController {
     @PostMapping("/create/{userId}/{musicalId}")
     public ResponseEntity<ScopeEntity> createScope(@PathVariable("musicalId") Long musicalId,
                                                    @PathVariable("userId") Long userId,
-                                                   @RequestBody ScopeEntity scopeEntity) {
-        scopeEntity.setMusicalId(musicalId);  // musicalId 설정
-        scopeEntity.setUserId(userId);        // userId 설정
-        ScopeEntity createdRating = scopeService.createOrUpdateScope(scopeEntity);
+                                                   @RequestBody ScopeVO scopeVO) {
+        ScopeEntity createdRating = scopeService.createOrUpdateScope(musicalId, userId, scopeVO);
         return new ResponseEntity<>(createdRating, HttpStatus.CREATED);
     }
 
@@ -32,10 +31,8 @@ public class ScopeController {
     @PutMapping("/update/{userId}/{musicalId}")
     public ResponseEntity<ScopeEntity> updateScope(@PathVariable("musicalId") Long musicalId,
                                                    @PathVariable("userId") Long userId,
-                                                   @RequestBody ScopeEntity scopeEntity) {
-        scopeEntity.setMusicalId(musicalId);  // musicalId 설정
-        scopeEntity.setUserId(userId);        // userId 설정
-        ScopeEntity updatedRating = scopeService.createOrUpdateScope(scopeEntity);
+                                                   @RequestBody ScopeVO scopeVO) {
+        ScopeEntity updatedRating = scopeService.createOrUpdateScope(musicalId, userId, scopeVO);
         return new ResponseEntity<>(updatedRating, HttpStatus.OK);
     }
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/dto/ScopeDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/dto/ScopeDTO.java
@@ -1,0 +1,17 @@
+package com.threeping.mudium.scope.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class ScopeDTO {
+
+    private Long musicalId;
+
+    private byte scope;
+
+    private String nickName;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/repository/ScopeRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/repository/ScopeRepository.java
@@ -3,10 +3,21 @@ package com.threeping.mudium.scope.repository;
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
 import com.threeping.mudium.scope.aggregate.entity.ScopeId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ScopeRepository extends JpaRepository<ScopeEntity, ScopeId> {
 
     void deleteScopeByMusicalIdAndUserId(Long musicalId, Long userId);
+
+    List<ScopeEntity> findAllScopeByMusicalId(Long musicalId);
+
+    @Query("SELECT s.musicalId, COALESCE(AVG(s.scope), 0.0) FROM ScopeEntity s WHERE s.musicalId IN :musicalIds GROUP BY s.musicalId")
+    List<Object[]> findAverageScopesByMusicalIds(@Param("musicalIds") List<Long> musicalIds);
+
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeService.java
@@ -1,13 +1,22 @@
 package com.threeping.mudium.scope.service;
 
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
+import com.threeping.mudium.scope.dto.ScopeDTO;
+import com.threeping.mudium.scope.vo.ScopeVO;
+
+import java.util.List;
+import java.util.Map;
 
 public interface ScopeService {
 
 //    ScopeEntity createScope(ScopeEntity scopeEntity);
 //
 //    ScopeEntity updateScope(ScopeEntity scopeEntity);
-    ScopeEntity createOrUpdateScope(ScopeEntity scopeEntity);
+    ScopeEntity createOrUpdateScope(Long musicalId, Long userId, ScopeVO scopeVO);
 
     void deleteScope(Long musicalId, Long userId);
+
+    List<ScopeDTO> findAllScopesByMusicalId(Long musicalId);
+
+    Map<Long, String> calculateAverageScopeBatch(List<Long> musicalIds);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeServiceImpl.java
@@ -1,24 +1,81 @@
     package com.threeping.mudium.scope.service;
 
+    import com.threeping.mudium.common.exception.CommonException;
+    import com.threeping.mudium.common.exception.ErrorCode;
     import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
     import com.threeping.mudium.scope.aggregate.entity.ScopeId;
+    import com.threeping.mudium.scope.dto.ScopeDTO;
     import com.threeping.mudium.scope.repository.ScopeRepository;
+    import com.threeping.mudium.scope.vo.ScopeVO;
+    import com.threeping.mudium.user.aggregate.entity.UserEntity;
+    import com.threeping.mudium.user.service.UserService;
     import org.springframework.stereotype.Service;
     import org.springframework.transaction.annotation.Transactional;
 
     import java.sql.Timestamp;
     import java.time.LocalDateTime;
+    import java.util.HashMap;
+    import java.util.List;
+    import java.util.Map;
+    import java.util.stream.Collectors;
 
     @Service
     public class ScopeServiceImpl implements ScopeService {
 
         private final ScopeRepository scopeRepository;
+        private final UserService userService;
 
-        public ScopeServiceImpl(ScopeRepository scopeRepository) {
+        public ScopeServiceImpl(ScopeRepository scopeRepository, UserService userService) {
             this.scopeRepository = scopeRepository;
+            this.userService = userService;
         }
 
-//        // 별점 추가
+        @Override
+        @Transactional
+        public List<ScopeDTO> findAllScopesByMusicalId(Long musicalId) {
+            List<ScopeEntity> entityList = scopeRepository.findAllScopeByMusicalId(musicalId);
+
+            // 특정 뮤지컬에 대한 모든 별점을 보며울 때 줄 거 = 뮤지컬 id, user 정보(닉네임), 별점
+            List<ScopeDTO> dtoList = entityList.stream()
+                    .map(scopeEntity -> {
+                        ScopeDTO dto = new ScopeDTO();
+                        dto.setMusicalId(scopeEntity.getMusicalId());
+                        dto.setScope(scopeEntity.getScope());
+                        dto.setNickName(scopeEntity.getUserNickname());
+                        return dto;
+                    }).collect(Collectors.toList());
+
+            return dtoList;
+        }
+
+        @Override
+        @Transactional(readOnly = true)
+        public Map<Long, String> calculateAverageScopeBatch(List<Long> musicalIds) {
+            List<Object[]> results = scopeRepository.findAverageScopesByMusicalIds(musicalIds);
+            Map<Long, String> averageScopes = new HashMap<>();
+
+            for (Object[] r : results) {
+                Long musicalId = (Long) r[0];
+                Double averageScope = (Double) r[1];
+                averageScopes.put(musicalId, averageConverter(averageScope));
+            }
+
+            // 결과에 포함되지 않은 뮤지컬은 평균 별점을 모두 0점으로 세팅
+            for (Long musicalId : musicalIds) {
+                averageScopes.putIfAbsent(musicalId, "0점");
+            }
+
+            return averageScopes;
+        }
+
+        private String averageConverter(Double average) {
+
+            double roundedScope = Math.ceil(average * 100) / 100.0;
+
+            return String.format("%.1f", roundedScope);
+        }
+
+        //        // 별점 추가
 //        @Override
 //        public ScopeEntity createScope(ScopeEntity scopeEntity) {
 //            scopeEntity.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
@@ -34,20 +91,24 @@
 
         // 별점 추가/수정 로직
         @Override
-        public ScopeEntity createOrUpdateScope(ScopeEntity scopeEntity) {
-            ScopeId scopeId = new ScopeId(scopeEntity.getMusicalId(), scopeEntity.getUserId());
-
+        public ScopeEntity createOrUpdateScope(Long musicalId, Long userId, ScopeVO scopeVO) {
+            ScopeId scopeId = new ScopeId(musicalId, userId);
+//            UserEntity user = userService.getUserByUserId(userId);
             // 기존 별점 존재 여부 확인
             ScopeEntity existingScope = scopeRepository.findById(scopeId).orElse(null);
 
             if (existingScope != null) {
                 // 별점이 이미 존재하는 경우 -> 수정
-                existingScope.setScope(scopeEntity.getScope());
+                existingScope.setScope(scopeVO.getScope());
                 existingScope.setUpdatedAt(Timestamp.valueOf(LocalDateTime.now()));
                 return scopeRepository.save(existingScope);
             } else {
                 // 별점이 없는 경우 -> 새로 추가
+                ScopeEntity scopeEntity = new ScopeEntity();
+                scopeEntity.setMusicalId(musicalId);
+                scopeEntity.setScope(scopeVO.getScope());
                 scopeEntity.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+                scopeEntity.setUserId(userId);
                 return scopeRepository.save(scopeEntity);
             }
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/vo/ScopeVO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/vo/ScopeVO.java
@@ -1,0 +1,13 @@
+package com.threeping.mudium.scope.vo;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class ScopeVO {
+
+    private byte Scope;
+}

--- a/MUDIUM/src/test/java/com/threeping/mudium/customticket/service/CustomTicketServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/customticket/service/CustomTicketServiceImplTests.java
@@ -28,7 +28,7 @@ class CustomTicketServiceImplTests {
     @Test
     public void testCreateCustomTicket() {
         // 테스트용 뮤지컬 생성 및 저장
-        Musical musical = new Musical(null, "Test Musical", "4.5", "url", "poster", 0);
+        Musical musical = new Musical(1L, "Test Musical", "전체관람가", "url", "poster", 0, "production", "synopsys");
         musical = musicalRepository.save(musical); // 저장된 뮤지컬 객체
 
         // 커스텀 티켓 생성
@@ -50,7 +50,7 @@ class CustomTicketServiceImplTests {
     @Test
     public void testUpdateCustomTicket() {
         // 먼저 생성된 뮤지컬과 티켓 저장
-        Musical musical = new Musical(null, "Test Musical", "4.5", "url", "poster", 0);
+        Musical musical = new Musical(1L, "Test Musical", "전체관람가", "url", "poster", 0, "production", "synopsys");
         musical = musicalRepository.save(musical);
 
         CustomTicketDTO customTicketDTO = new CustomTicketDTO(
@@ -84,7 +84,7 @@ class CustomTicketServiceImplTests {
     @Test
     public void testDeleteCustomTicket() {
         // 먼저 생성된 뮤지컬과 티켓 저장
-        Musical musical = new Musical(null, "Test Musical", "4.5", "url", "poster", 0);
+        Musical musical = new Musical(1L, "Test Musical", "전체관람가", "url", "poster", 0, "production", "synopsys");
         musical = musicalRepository.save(musical);
 
         CustomTicketDTO customTicketDTO = new CustomTicketDTO(

--- a/MUDIUM/src/test/java/com/threeping/mudium/musical/service/MusicalServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/musical/service/MusicalServiceImplTests.java
@@ -1,11 +1,16 @@
 package com.threeping.mudium.musical.service;
 
+import com.threeping.mudium.musical.dto.MusicalListDTO;
 import com.threeping.mudium.musical.dto.MusicalTotalDTO;
 import com.threeping.mudium.performance.dto.PerformanceDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -25,7 +30,7 @@ class MusicalServiceImplTests {
     @Test
     void musicalDetailViewTest() {
         // given
-        Long musicId = 1L;
+        Long musicId = 3L;
 
         // when
         MusicalTotalDTO musicalDetail = musicalService.findMusicalDetail(musicId);
@@ -34,5 +39,41 @@ class MusicalServiceImplTests {
         // then
         assertNotNull(musicalDetail, "조회된 뮤지컬 상세 정보는 null이 아니다.");
         assertFalse(list.isEmpty(), "조회된 뮤지컬의 공연 정보는 비어있지 않다.");
+    }
+
+
+    @DisplayName("모든 뮤지컬 정보를 페이징 조회한다.")
+    @Test
+    void viewMusicalList() {
+        // given
+        Pageable pageable = PageRequest.of(1, 12, Sort.by("viewCount").descending());
+        String title = "";
+
+        // when
+        Page<MusicalListDTO> dtoPage = musicalService.findByName(title, pageable);
+
+        // then
+        assertNotNull(dtoPage, "조회된 페이징 뮤지컬 정보 객체는 null이 아니다.");
+        assertTrue(dtoPage.hasContent(), "조회된 페이징 뮤지컬 정보는 내용을 갖고 있다.");
+        assertEquals(12, dtoPage.getSize(), "조회된 뮤지컬 정보는 페이지당 12개이다.");
+    }
+
+    @DisplayName("뮤지컬 이름으로 조회한다.")
+    @Test
+    void searchByTitle() {
+        // given
+        Pageable pageable = PageRequest.of(1, 10, Sort.by("viewCount").descending());
+        String title = "빨간";
+
+        // when
+        Page<MusicalListDTO> dtoPage = musicalService.findByName(title, pageable);
+        List<MusicalListDTO> dtoList = dtoPage.getContent();
+        for (MusicalListDTO dto : dtoList) {
+            System.out.println(dto.getTitle());
+        }
+
+        // then
+        assertNotNull(dtoPage, "검색된 이름으로 조회된 뮤지컬은 null이 아니다.");
+        assertTrue(dtoPage.hasContent(), "검색된 이름으로 조회된 페이징 객체는 내용을 갖고 있다.");
     }
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/scope/service/ScopeServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/scope/service/ScopeServiceImplTests.java
@@ -3,6 +3,7 @@ package com.threeping.mudium.scope.service;
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
 import com.threeping.mudium.scope.aggregate.entity.ScopeId;
 import com.threeping.mudium.scope.repository.ScopeRepository;
+import com.threeping.mudium.scope.vo.ScopeVO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,10 +31,11 @@ class ScopeServiceImplTests {
         // DB에 이미 존재하는 회원 ID와 뮤지컬 ID 사용
         Long existingUserId = 1L;
         Long existingMusicalId = 1L;
+        ScopeVO scopeVO = new ScopeVO((byte) 5);
+
 
         // 새로운 별점 추가 테스트
-        ScopeEntity scopeEntity = new ScopeEntity(existingMusicalId, existingUserId, (byte) 5, null, null);
-        ScopeEntity savedScope = scopeService.createOrUpdateScope(scopeEntity);
+        ScopeEntity savedScope = scopeService.createOrUpdateScope(existingMusicalId, existingUserId, scopeVO);
 
         // 별점이 정상적으로 추가되었는지 확인
         assertNotNull(savedScope);
@@ -43,12 +45,11 @@ class ScopeServiceImplTests {
     @Test
     public void testUpdateScope() {
         // 기존에 별점이 있는 경우 수정 테스트
-        ScopeEntity existingScope = new ScopeEntity(1L, 1L, (byte) 4, Timestamp.valueOf(LocalDateTime.now()), null);
+        ScopeEntity existingScope = new ScopeEntity(1L, 1L, (byte) 4, Timestamp.valueOf(LocalDateTime.now()), null, "닉네임");
         scopeRepository.save(existingScope);
 
         // 기존 별점을 5로 수정
-        ScopeEntity updatedScope = new ScopeEntity(1L, 1L, (byte) 5, null, null);
-        ScopeEntity result = scopeService.createOrUpdateScope(updatedScope);
+        ScopeEntity result = scopeService.createOrUpdateScope(1L, 1L, new ScopeVO((byte) 4));
 
         // 별점이 정상적으로 수정되었는지 확인
         assertNotNull(result);


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 만든 기능 상세히 설명하자
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [x] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 원래 코드에서는 각 뮤지컬마다 개별적으로 평균 별점을 조회하는 방식을 사용했습니다. 이로 인해 N+1 문제가 발생했습니다. 즉, 뮤지컬 목록을 조회하는 쿼리 1번, 그리고 각 뮤지컬의 평균 별점을 조회하는 쿼리 N번이 실행되었습니다.
- N+1 문제 해결 방법:
모든 관련 뮤지컬의 평균 별점을 한 번의 쿼리로 조회하는 배치 처리 방식을 도입했습니다. 이를 위해 calculateAverageScopesBatch 메서드를 구현하고, 이 메서드 내에서 한 번의 쿼리로 여러 뮤지컬의 평균 별점을 조회하도록 했습니다.

## 어떤 부분에 리뷰어가 집중하면 좋은가
```
@Query("SELECT s.musicalId, COALESCE(AVG(s.scope), 0.0) FROM ScopeEntity s WHERE s.musicalId IN :musicalIds GROUP BY s.musicalId")
List<Object[]> findAverageScopesByMusicalIds(@Param("musicalIds") List<Long> musicalIds);
```
JPQL과 List로 한 번에 조회할 뮤지컬 PK를 받게 함으로써 뮤지컬 정보 조회 쿼리 1번, 전체 결과 수 조회를 위한 COUNT 쿼리 1번, 모든 관련 뮤지컬의 평균 별점을 조회하는 쿼리 1번
총 3번의 쿼리만으로 필요한 모든 정보를 조회할 수 있게 되었습니다.
물론 페이징 요청이 최대 페이지를 넘어가게 될 경우 내부 메서드에 따라 최대 페이징 조정을 위한 2번의 쿼리가 발생합니다.
이는 최적화되지 않은 상태이므로 추후에 개선할 에정입니다.

## 관련 스크린 샷 
'빨간'을 검색어로 입력했을 때, 제목에 '빨간'이 들어가는 뮤지컬을 조회수 순으로 페이징 처리해서 조회
뮤지컬을 조회 시, 평균 별점도 조회되도록 기능 개발
<img width="836" alt="image" src="https://github.com/user-attachments/assets/fd4e17a0-0ed7-47ad-81a7-0f61e88765a6">



## 테스트 계획 또는 완료 사항
- [x] 검색어를 통해 뮤지컬 조회
- [x] 뮤지컬 조회 시 평균 별점 계산(별점이 하나도 없을 시, 0점으로 처리)
