### PR TITLE
[공지게시글] 공지게시글 조회 기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/ActiveStatus.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/entity/ActiveStatus.java
@@ -1,6 +1,0 @@
-package com.threeping.mudium.board.aggregate.entity;
-
-public enum ActiveStatus {
-    ACTIVE,
-    INACTIVE
-}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/enumerate/ActiveStatus.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/enumerate/ActiveStatus.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.board.aggregate.enumerate;
+
+public enum ActiveStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/enumerate/SearchType.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/aggregate/enumerate/SearchType.java
@@ -1,0 +1,7 @@
+package com.threeping.mudium.board.aggregate.enumerate;
+
+public enum SearchType {
+    NICKNAME,
+    TITLE,
+    CONTENT
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.threeping.mudium.board.controller;
 
+import com.threeping.mudium.board.aggregate.enumerate.SearchType;
 import com.threeping.mudium.board.dto.BoardDetailDTO;
 import com.threeping.mudium.board.dto.BoardListDTO;
 import com.threeping.mudium.board.dto.RegistBoardDTO;
@@ -24,26 +25,14 @@ public class BoardController {
 
     @GetMapping("")
     public ResponseDTO<?> viewBoardPage(
-            @RequestParam(required = false) String searchType,
+            @RequestParam(required = false) SearchType searchType,
             @RequestParam(required = false) String searchQuery,
             Pageable pageable) {
 
         Page<BoardListDTO> boardPage;
 
         if (searchType != null && searchQuery != null && !searchQuery.trim().isEmpty()) {
-            switch (searchType) {
-                case "author":
-                    boardPage = boardService.searchBoardsByUser_NickName(searchQuery, pageable);
-                    break;
-                case "title":
-                    boardPage = boardService.searchBoardsByTitle(searchQuery, pageable);
-                    break;
-                case "content":
-                    boardPage = boardService.searchBoardsByContent(searchQuery, pageable);
-                    break;
-                default:
-                    boardPage = boardService.viewBoardList(pageable);
-            }
+            boardPage = boardService.viewSearchedBoardList(pageable,searchType,searchQuery);
         } else {
             boardPage = boardService.viewBoardList(pageable);
         }

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/controller/BoardController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/board")
 public class BoardController {
 
-    private BoardService boardService;
+    private final BoardService  boardService;
 
     @Autowired
     private BoardController(BoardService boardService){
@@ -60,10 +60,12 @@ public class BoardController {
         return ResponseDTO.ok(null);
     }
 
-    @DeleteMapping("{boardId}")
+    @DeleteMapping("{boardId}/{userId}")
     private ResponseDTO<?> deleteBoard(@PathVariable Long boardId,
-                                       @RequestBody UpdateBoardDTO updateBoardDTO){
+                                       @PathVariable Long userId){
+        UpdateBoardDTO updateBoardDTO = new UpdateBoardDTO();
         updateBoardDTO.setBoardId(boardId);
+        updateBoardDTO.setUserId(userId);
         boardService.deleteBoard(updateBoardDTO);
         return ResponseDTO.ok(null);
     }}

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardDetailDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardDetailDTO.java
@@ -17,4 +17,5 @@ public class BoardDetailDTO {
     private Long userId;
     private Timestamp createdAt;
     private Timestamp updatedAt;
+    private Long boardLike;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/dto/BoardListDTO.java
@@ -1,6 +1,5 @@
 package com.threeping.mudium.board.dto;
 
-import com.threeping.mudium.board.aggregate.entity.ActiveStatus;
 import lombok.*;
 
 import java.sql.Timestamp;
@@ -16,4 +15,5 @@ public class BoardListDTO {
     private String nickname;
     private Long userId;
     private Timestamp createdAt;
+    private Long boardLike;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/repository/BoardRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/repository/BoardRepository.java
@@ -1,6 +1,6 @@
 package com.threeping.mudium.board.repository;
 
-import com.threeping.mudium.board.aggregate.entity.ActiveStatus;
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
 import com.threeping.mudium.board.aggregate.entity.Board;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.threeping.mudium.board.service;
 
+import com.threeping.mudium.board.aggregate.enumerate.SearchType;
 import com.threeping.mudium.board.dto.BoardDetailDTO;
 import com.threeping.mudium.board.dto.BoardListDTO;
 import com.threeping.mudium.board.dto.RegistBoardDTO;
@@ -18,9 +19,5 @@ public interface BoardService {
 
     void deleteBoard(UpdateBoardDTO updateBoardDTO);
 
-    Page<BoardListDTO> searchBoardsByUser_NickName(String nickname, Pageable pageable);
-
-    Page<BoardListDTO> searchBoardsByTitle(String searchQuery, Pageable pageable);
-
-    Page<BoardListDTO> searchBoardsByContent(String searchQuery, Pageable pageable);
+    Page<BoardListDTO> viewSearchedBoardList(Pageable pageable, SearchType searchType, String searchQuery);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/board/service/BoardServiceImpl.java
@@ -1,7 +1,8 @@
 package com.threeping.mudium.board.service;
 
-import com.threeping.mudium.board.aggregate.entity.ActiveStatus;
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
 import com.threeping.mudium.board.aggregate.entity.Board;
+import com.threeping.mudium.board.aggregate.enumerate.SearchType;
 import com.threeping.mudium.board.dto.BoardDetailDTO;
 import com.threeping.mudium.board.dto.BoardListDTO;
 import com.threeping.mudium.board.dto.RegistBoardDTO;
@@ -128,21 +129,32 @@ public class BoardServiceImpl implements BoardService {
     }
 
 
-
-
-    @Override
     public Page<BoardListDTO> searchBoardsByUser_NickName(String nickname, Pageable pageable) {
         return boardRepository.findByUser_NicknameContaining(nickname, pageable).map(this::convertToDTO);
     }
 
-    @Override
     public Page<BoardListDTO> searchBoardsByTitle(String title, Pageable pageable) {
         return boardRepository.findByTitleContaining(title, pageable).map(this::convertToDTO);
     }
 
-    @Override
     public Page<BoardListDTO> searchBoardsByContent(String content, Pageable pageable) {
         return boardRepository.findByContentContaining(content, pageable).map(this::convertToDTO);
+    }
+
+    @Override
+    public Page<BoardListDTO> viewSearchedBoardList(Pageable pageable, SearchType searchType, String searchQuery) {
+        int pageNumber = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable boardPageable = PageRequest.of(pageNumber,pageSize,pageSort);
+        if (searchType.equals(SearchType.NICKNAME)) {
+            return searchBoardsByUser_NickName(searchQuery,boardPageable);
+        } else if (searchType.equals(SearchType.TITLE)){
+            return searchBoardsByTitle(searchQuery,boardPageable);
+        } else if (searchType.equals(SearchType.CONTENT)) {
+            return searchBoardsByContent(searchQuery,boardPageable);
+        }
+        return null;
     }
 
     private BoardListDTO convertToDTO(Board board) {

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/aggregate/entity/BoardLike.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/aggregate/entity/BoardLike.java
@@ -1,0 +1,24 @@
+package com.threeping.mudium.boardlike.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@Entity
+@Table(name = "TBL_BOARD_LIKE")
+@IdClass(BoardLikePK.class)
+public class BoardLike {
+    @Id
+    @Column(name="board_id")
+    private Long boardId;
+
+    @Id
+    @Column(name="user_id")
+    private Long userId;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/aggregate/entity/BoardLikePK.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/aggregate/entity/BoardLikePK.java
@@ -1,0 +1,15 @@
+package com.threeping.mudium.boardlike.aggregate.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class BoardLikePK implements Serializable {
+    private Long boardId;
+    private Long userId;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/controller/BoardLikeController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/controller/BoardLikeController.java
@@ -1,0 +1,43 @@
+package com.threeping.mudium.boardlike.controller;
+
+import com.threeping.mudium.boardlike.service.BoardLikeService;
+import com.threeping.mudium.common.ResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/board-like")
+public class BoardLikeController {
+
+    private final BoardLikeService boardLikeService;
+
+    @Autowired
+    private BoardLikeController(BoardLikeService boardLikeService){
+        this.boardLikeService = boardLikeService;
+    }
+
+    @GetMapping("{boardId}/{userId}")
+    private ResponseDTO<?> findBoardLike(@PathVariable Long boardId,
+                                         @PathVariable Long userId){
+        Boolean isExist = boardLikeService.findBoardLike(boardId,userId);
+        return ResponseDTO.ok(isExist);
+    }
+
+    @PostMapping("{boardId}")
+    private ResponseDTO<?> createBoardLike(@PathVariable Long boardId,
+                                           @RequestBody Long userId){
+        boardLikeService.createBoardLike(boardId,userId);
+        return ResponseDTO.ok(null);
+    }
+
+    @DeleteMapping("{boardId}")
+    private ResponseDTO<?> deleteBoardLike(@PathVariable Long boardId,
+                                           @RequestBody Long userId){
+        boardLikeService.deleteBoardLike(boardId,userId);
+        log.info("delete?");
+        return ResponseDTO.ok(null);
+    }
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/repository/BoardLikeRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/repository/BoardLikeRepository.java
@@ -1,0 +1,8 @@
+package com.threeping.mudium.boardlike.repository;
+
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLike;
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLikePK;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, BoardLikePK> {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/service/BoardLikeService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/service/BoardLikeService.java
@@ -1,0 +1,9 @@
+package com.threeping.mudium.boardlike.service;
+
+public interface BoardLikeService {
+    void createBoardLike(Long boardId, Long userId);
+
+    void deleteBoardLike(Long boardId, Long userId);
+
+    Boolean findBoardLike(Long boardId, Long userId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImpl.java
@@ -1,0 +1,42 @@
+package com.threeping.mudium.boardlike.service;
+
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLike;
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLikePK;
+import com.threeping.mudium.boardlike.repository.BoardLikeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BoardLikeServiceImpl implements BoardLikeService{
+
+    private final BoardLikeRepository boardLikeRepository;
+
+    @Autowired
+     BoardLikeServiceImpl(BoardLikeRepository boardLikeRepository){
+        this.boardLikeRepository = boardLikeRepository;
+    }
+
+    @Override
+    @Transactional
+    public Boolean findBoardLike(Long boardId, Long userId) {
+        BoardLike boardLike = boardLikeRepository.findById(new BoardLikePK(boardId,userId)).orElse(null);
+        return boardLike != null;
+    }
+
+    @Override
+    @Transactional
+    public void createBoardLike(Long boardId, Long userId) {
+        BoardLike boardLike = new BoardLike(boardId,userId);
+        boardLikeRepository.save(boardLike);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBoardLike(Long boardId, Long userId) {
+        BoardLikePK boardLikePK = new BoardLikePK(boardId,userId);
+        boardLikeRepository.deleteById(boardLikePK);
+    }
+
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -81,7 +81,9 @@ public enum ErrorCode {
 
     //Board
     INVALID_BOARD_ID(4002101,HttpStatus.BAD_REQUEST,"잘못된 자유게시글 번호입니다."),
-    INVALID_BOARD_USER_ID(4002102,HttpStatus.BAD_REQUEST,"수정 권한이 없는 게시글입니다.");
+    INVALID_BOARD_USER_ID(4002102,HttpStatus.BAD_REQUEST,"수정 권한이 없는 게시글입니다."),
+    //Notice
+    INVALID_NOTICE_ID(4002201,HttpStatus.BAD_REQUEST ,"잘못된 공지게시글 번호입니다." );
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/aggregate/entity/Notice.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/aggregate/entity/Notice.java
@@ -1,6 +1,5 @@
-package com.threeping.mudium.board.aggregate.entity;
+package com.threeping.mudium.notice.aggregate.entity;
 
-import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
 import com.threeping.mudium.user.aggregate.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,17 +7,17 @@ import lombok.*;
 import java.sql.Timestamp;
 
 @Entity
-@Table(name = "TBL_BOARD")
+@Table(name = "TBL_NOTICE")
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 @Setter
 @ToString
-public class Board {
+public class Notice {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "board_id")
-    private int boardId;
+    @Column(name = "notice_id")
+    private Long noticeId;
 
     @Column(name = "title")
     private String title;
@@ -34,13 +33,6 @@ public class Board {
 
     @Column(name = "view_count")
     private Long viewCount;
-
-    @Column(name = "boardLike")
-    private Long boardLike;
-
-    @Column(name = "active_status")
-    @Enumerated(EnumType.STRING)
-    private ActiveStatus activeStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/aggregate/enumerate/SearchType.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/aggregate/enumerate/SearchType.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.notice.aggregate.enumerate;
+
+public enum SearchType {
+    TITLE,
+    CONTENT
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/controller/NoticeController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/controller/NoticeController.java
@@ -1,0 +1,26 @@
+package com.threeping.mudium.notice.controller;
+
+import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.notice.service.NoticeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notice")
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Autowired
+    private NoticeController(NoticeService noticeService){
+        this.noticeService = noticeService;
+    }
+
+    @GetMapping("")
+    private ResponseDTO<?> findAllNotice(){
+
+        return ResponseDTO.ok(null);
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/controller/NoticeController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/controller/NoticeController.java
@@ -1,11 +1,14 @@
 package com.threeping.mudium.notice.controller;
 
+import com.threeping.mudium.notice.aggregate.enumerate.SearchType;
 import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.notice.dto.NoticeDetailDTO;
+import com.threeping.mudium.notice.dto.NoticeListDTO;
 import com.threeping.mudium.notice.service.NoticeService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/notice")
@@ -19,8 +22,25 @@ public class NoticeController {
     }
 
     @GetMapping("")
-    private ResponseDTO<?> findAllNotice(){
+    public ResponseDTO<?> viewNoticePage(
+            @RequestParam(required = false) SearchType searchType,
+            @RequestParam(required = false) String searchQuery,
+            Pageable pageable) {
 
-        return ResponseDTO.ok(null);
+        Page<NoticeListDTO> noticePage;
+
+        if (searchType != null && searchQuery != null && !searchQuery.trim().isEmpty()) {
+            noticePage = noticeService.viewSearchedNoticeList(pageable,searchType,searchQuery);
+        } else {
+            noticePage = noticeService.viewBoardList(pageable);
+        }
+
+        return ResponseDTO.ok(noticePage);
+    }
+
+    @GetMapping("{noticeId}")
+    private ResponseDTO<?> viewDetailNotice(@PathVariable Long noticeId){
+        NoticeDetailDTO noticeDetail = noticeService.viewNotice(noticeId);
+        return ResponseDTO.ok(noticeDetail);
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/dto/NoticeDetailDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/dto/NoticeDetailDTO.java
@@ -1,0 +1,18 @@
+package com.threeping.mudium.notice.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class NoticeDetailDTO {
+    private Long noticeId;
+    private String title;
+    private String content;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/dto/NoticeListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/dto/NoticeListDTO.java
@@ -1,0 +1,19 @@
+package com.threeping.mudium.notice.dto;
+
+import com.threeping.mudium.user.aggregate.entity.UserRole;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class NoticeListDTO {
+    private Long id;
+    private UserRole userRole;
+    private String title;
+    private Long userId;
+    private Timestamp createdAt;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/repository/NoticeRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package com.threeping.mudium.notice.repository;
+
+import com.threeping.mudium.notice.aggregate.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/repository/NoticeRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/repository/NoticeRepository.java
@@ -1,7 +1,13 @@
 package com.threeping.mudium.notice.repository;
 
 import com.threeping.mudium.notice.aggregate.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface NoticeRepository extends JpaRepository<Notice,Long> {
+    Page<Notice> findByTitleContaining(String title, Pageable pageable);
+
+    Page<Notice> findByContentContaining(String content, Pageable pageable);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeService.java
@@ -1,0 +1,3 @@
+package com.threeping.mudium.notice.service;
+public interface NoticeService {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeService.java
@@ -1,3 +1,15 @@
 package com.threeping.mudium.notice.service;
+
+import com.threeping.mudium.notice.aggregate.enumerate.SearchType;
+import com.threeping.mudium.notice.dto.NoticeDetailDTO;
+import com.threeping.mudium.notice.dto.NoticeListDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface NoticeService {
+    Page<NoticeListDTO> viewSearchedNoticeList(Pageable pageable, SearchType searchType, String searchQuery);
+
+    Page<NoticeListDTO> viewBoardList(Pageable pageable);
+
+    NoticeDetailDTO viewNotice(Long noticeId);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeServiceImpl.java
@@ -1,0 +1,7 @@
+package com.threeping.mudium.notice.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class NoticeServiceImpl implements NoticeService {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/notice/service/NoticeServiceImpl.java
@@ -1,7 +1,94 @@
 package com.threeping.mudium.notice.service;
 
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.notice.aggregate.enumerate.SearchType;
+import com.threeping.mudium.notice.aggregate.entity.Notice;
+import com.threeping.mudium.notice.dto.NoticeDetailDTO;
+import com.threeping.mudium.notice.dto.NoticeListDTO;
+import com.threeping.mudium.notice.repository.NoticeRepository;
+import com.threeping.mudium.user.repository.UserRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class NoticeServiceImpl implements NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final ModelMapper modelMapper;
+    private final UserRepository userRepository;
+
+    @Autowired
+    NoticeServiceImpl(NoticeRepository noticeRepository,
+                     ModelMapper modelMapper,
+                      UserRepository userRepository){
+        this.noticeRepository = noticeRepository;
+        this.modelMapper = modelMapper;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Page<NoticeListDTO> viewBoardList(Pageable pageable) {
+        int pageNumber = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable noticePageable = PageRequest.of(pageNumber,pageSize,pageSort);
+
+        Page<Notice> notices = noticeRepository.findAll(noticePageable);
+
+        List<NoticeListDTO> boardListDTOList = notices.stream()
+                .map(notice -> {
+                    NoticeListDTO noticeListDTO = modelMapper.map(notice, NoticeListDTO.class);
+                    return noticeListDTO;
+                })
+                .collect(Collectors.toList());
+        Page<NoticeListDTO> noticeListDTOs = new PageImpl<>(boardListDTOList,noticePageable,notices.getTotalElements());
+
+        return noticeListDTOs;
+    }
+
+    @Override
+    public Page<NoticeListDTO> viewSearchedNoticeList(Pageable pageable, SearchType searchType, String searchQuery) {
+        int pageNumber = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable noticePageable = PageRequest.of(pageNumber,pageSize,pageSort);
+        if (searchType.equals(SearchType.TITLE)) {
+            return searchNoticeByTitle(searchQuery,noticePageable);
+        } else if (searchType.equals(SearchType.CONTENT)) {
+            return searchNoticeByContent(searchQuery,noticePageable);
+        }
+        return null;
+    }
+
+    @Override
+    public NoticeDetailDTO viewNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId).orElseThrow
+                (()->new CommonException(ErrorCode.INVALID_NOTICE_ID));
+        NoticeDetailDTO noticeDetailDTO = modelMapper.map(notice,NoticeDetailDTO.class);
+        return noticeDetailDTO;
+    }
+
+    public Page<NoticeListDTO> searchNoticeByTitle(String title, Pageable pageable) {
+        return noticeRepository.findByTitleContaining(title, pageable).map(this::convertToDTO);
+    }
+
+    public Page<NoticeListDTO> searchNoticeByContent(String content, Pageable pageable) {
+        return noticeRepository.findByContentContaining(content, pageable).map(this::convertToDTO);
+    }
+
+    private NoticeListDTO convertToDTO(Notice notice) {
+        NoticeListDTO noticeListDTO = new NoticeListDTO();
+        noticeListDTO.setTitle(notice.getTitle());
+        noticeListDTO.setId(notice.getNoticeId());
+        noticeListDTO.setCreatedAt(notice.getCreatedAt());
+        noticeListDTO.setUserId(notice.getUser().getUserId());
+        return noticeListDTO;
+    }
+
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/board/service/BoardServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/board/service/BoardServiceImplTests.java
@@ -7,7 +7,7 @@ import com.threeping.mudium.board.dto.RegistBoardDTO;
 import com.threeping.mudium.board.dto.UpdateBoardDTO;
 import com.threeping.mudium.board.repository.BoardRepository;
 import com.threeping.mudium.common.exception.CommonException;
-import com.threeping.mudium.board.aggregate.entity.ActiveStatus;
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +17,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.Timestamp;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/MUDIUM/src/test/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImplTests.java
@@ -1,0 +1,35 @@
+package com.threeping.mudium.boardlike.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BoardLikeServiceImplTests {
+
+    private final BoardLikeService boardLikeService;
+
+    @Autowired
+    BoardLikeServiceImplTests(BoardLikeService boardLikeService){
+        this.boardLikeService = boardLikeService;
+    }
+
+    @DisplayName("자유게시글 좋아요를 조회한다.")
+    @Test
+    void findBoardLikeTest(){}
+
+    @DisplayName("자유게시글 좋아요를 등록한다.")
+    @Test
+    void createBoardLikeTest(){}
+
+    @DisplayName("자유게시글 좋아요를 삭제한다.")
+    @Test
+    void deleteBoardLikeTest(){}
+
+
+}

--- a/MUDIUM/src/test/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/boardlike/service/BoardLikeServiceImplTests.java
@@ -1,5 +1,8 @@
 package com.threeping.mudium.boardlike.service;
 
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLike;
+import com.threeping.mudium.boardlike.aggregate.entity.BoardLikePK;
+import com.threeping.mudium.boardlike.repository.BoardLikeRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,23 +16,55 @@ import static org.junit.jupiter.api.Assertions.*;
 class BoardLikeServiceImplTests {
 
     private final BoardLikeService boardLikeService;
+    private final BoardLikeRepository boardLikeRepository;
 
     @Autowired
-    BoardLikeServiceImplTests(BoardLikeService boardLikeService){
+    BoardLikeServiceImplTests(BoardLikeService boardLikeService,
+                              BoardLikeRepository boardLikeRepository){
         this.boardLikeService = boardLikeService;
+        this.boardLikeRepository = boardLikeRepository;
     }
 
-    @DisplayName("자유게시글 좋아요를 조회한다.")
+
     @Test
-    void findBoardLikeTest(){}
+    @DisplayName("게시글 좋아요를 찾는다.")
+    void findBoardLikeTest() {
+        Long boardId = -1L;
+        Long userId = -1L;
 
-    @DisplayName("자유게시글 좋아요를 등록한다.")
+        boardLikeService.createBoardLike(boardId, userId);
+        Boolean result = boardLikeService.findBoardLike(boardId, userId);
+        assertTrue(result, "좋아요가 존재해야 한다.");
+
+        Boolean nonExistentResult = boardLikeService.findBoardLike(-2L, -2L);
+        assertFalse(nonExistentResult, "존재하지 않는 좋아요는 false여야 한다.");
+    }
+
     @Test
-    void createBoardLikeTest(){}
+    @DisplayName("게시글 좋아요를 생성한다.")
+    void createBoardLikeTest() {
+        Long boardId = -1L;
+        Long userId = -1L;
 
-    @DisplayName("자유게시글 좋아요를 삭제한다.")
+        // 게시글 좋아요를 생성합니다.
+        boardLikeService.createBoardLike(boardId, userId);
+
+        BoardLikePK boardLikePK = new BoardLikePK(boardId, userId);
+        BoardLike boardLike = boardLikeRepository.findById(boardLikePK).orElse(null);
+        assertNotNull(boardLike, "좋아요가 저장되어 있어야 한다.");
+    }
+
     @Test
-    void deleteBoardLikeTest(){}
+    @DisplayName("게시글 좋아요를 삭제한다.")
+    void deleteBoardLikeTest() {
+        Long boardId = -1L;
+        Long userId = -1L;
 
+        boardLikeService.createBoardLike(boardId, userId);
+        boardLikeService.deleteBoardLike(boardId, userId);
 
+        BoardLikePK boardLikePK = new BoardLikePK(boardId, userId);
+        BoardLike boardLike = boardLikeRepository.findById(boardLikePK).orElse(null);
+        assertNull(boardLike, "좋아요가 삭제되어 있어야 한다.");
+    }
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/notice/service/NoticeServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/notice/service/NoticeServiceImplTests.java
@@ -1,0 +1,60 @@
+package com.threeping.mudium.notice.service;
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.notice.dto.NoticeDetailDTO;
+import com.threeping.mudium.notice.dto.NoticeListDTO;
+import com.threeping.mudium.notice.repository.NoticeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class NoticeServiceImplTests {
+
+    private final NoticeService noticeService;
+    private final NoticeRepository noticeRepository;
+
+    @Autowired
+    NoticeServiceImplTests(NoticeService noticeService,
+                           NoticeRepository noticeRepository){
+        this.noticeService = noticeService;
+        this.noticeRepository = noticeRepository;
+    }
+
+    @DisplayName("공지 게시글 리스트를 페이지로 조회한다.")
+    @Test
+    void noticePageViewTest() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+
+        Page<NoticeListDTO> noticeDTOPage = noticeService.viewBoardList(pageable);
+
+        assertNotNull(noticeDTOPage, "조회된 페이지는 null이 아니다.");
+        assertTrue(noticeDTOPage.hasContent(), "조회된 페이지는 내용이 있다.");
+        assertEquals(10, noticeDTOPage.getSize(), "페이지 크기는 10이다.");
+    }
+
+    @DisplayName("공지 게시글 상세 정보를 조회한다.")
+    @Test
+    void noticeDetailViewTest() {
+        Long noticeId = 1L;
+        Long invalidNoticeId = -1L;
+
+        NoticeDetailDTO firstNoticeDetail = noticeService.viewNotice(noticeId);
+
+        assertNotNull(firstNoticeDetail, "조회된 공지사항은 null이 아니다.");
+        assertEquals(noticeId, firstNoticeDetail.getNoticeId(), "조회된 공지사항 ID는 요청된 ID와 일치한다.");
+
+        Exception exception = assertThrows(CommonException.class,
+                () -> { noticeService.viewNotice(invalidNoticeId); });
+        assertEquals("잘못된 공지게시글 번호입니다.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
---
name: [공지게시글] 공지게시글 조회 기능 추가
about: 자유게시글과 똑같은 형태로 공지게시글 페이지 목록 조회 및 상세 조회 기능 구현
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 공지게시글에서는 관리자만 글을 쓰기 때문에 유저 닉네임이 표시가 되지 않으므로 조회 시 유저 닉네임을 가져오지 않습니다!!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/6b8b1ddf-12e8-4f65-95be-32b089e6961f)

## 테스트 계획 또는 완료 사항
- [x] 포스트맨 요청 정상 작동
- [x] 테스트 코드 통과
