### PR TITLE
[뮤지컬 게시판]ADD: 대댓글 CUD 기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -81,6 +81,7 @@ public enum ErrorCode {
     NOT_FOUND_MUSICAL(4041308, HttpStatus.NOT_FOUND, "존재하지 않는 뮤지컬입니다."),
     MISSING_REQUIRED_CONTENT(4001308, HttpStatus.BAD_REQUEST, "필수 내용이 누락되었습니다."),
     NOT_FOUND_COMMENT(4001309, HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
+    NOT_FOUND_REPLY(4001310, HttpStatus.NOT_FOUND, "대댓글이 존재하지 않습니다."),
 
 
     //Board

--- a/MUDIUM/src/main/java/com/threeping/mudium/mucialcomment/repository/MusicalCommentRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/mucialcomment/repository/MusicalCommentRepository.java
@@ -17,4 +17,6 @@ public interface MusicalCommentRepository extends JpaRepository<MusicalComment, 
 
     Optional<MusicalComment> findMusicalCommentByMusicalBoardCommentIdAndUserIdAndMusicalPostIdAndActiveStatus(
             Long musicalBoardCommentId, Long userId, Long postId, ActiveStatus activeStatus);
+
+    Optional<MusicalComment> findMusicalCommentByMusicalBoardCommentId(Long musicalBoardCommentId);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/mucialcomment/service/MusicalCommentService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/mucialcomment/service/MusicalCommentService.java
@@ -12,4 +12,6 @@ public interface MusicalCommentService {
     void updateComment(Long userId, MusicalCommentDTO commentDTO);
 
     void deleteComment(Long userId, MusicalCommentDTO commentDTO);
+
+    boolean existingCheck(Long commentId);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/MusicalPost.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/aggregate/MusicalPost.java
@@ -42,6 +42,9 @@ public class MusicalPost {
     @Column(name = "comments")
     private Long comments;
 
+//    @Column(name = "replys")
+//    private Long replys;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "active_status", nullable = false)
     private ActiveStatus activeStatus = ActiveStatus.ACTIVE;

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardService.java
@@ -18,4 +18,6 @@ public interface MusicalBoardService {
     void updatePost(Long musicalPostId, Long userId, MusicalPostDTO postDTO);
 
     void deletePost(Long musicalPostId, Long userId);
+
+    boolean existingCheck(Long postId);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalboard/service/MusicalBoardServiceImpl.java
@@ -146,4 +146,9 @@ public class MusicalBoardServiceImpl implements MusicalBoardService {
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy년 MM월 dd일 HH시 mm분 ss초");
         return sdf.format(date);
     }
+
+    @Override
+    public boolean existingCheck(Long postId) {
+        return musicalBoardRepository.findMusicalPostByMusicalPostIdAndActiveStatus(postId, ActiveStatus.ACTIVE).isPresent();
+    }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/aggregate/MusicalReply.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/aggregate/MusicalReply.java
@@ -39,4 +39,8 @@ public class MusicalReply {
 
     @Column(name = "user_id")
     private Long userId;
+
+    public void softDelete() {
+        this.activeStatus = ActiveStatus.INACTIVE;
+    }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/controller/MusicalReplyController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/controller/MusicalReplyController.java
@@ -3,12 +3,10 @@ package com.threeping.mudium.musicalreply.controller;
 import com.threeping.mudium.common.ResponseDTO;
 import com.threeping.mudium.musicalreply.dto.MusicalReplyDTO;
 import com.threeping.mudium.musicalreply.service.MusicalReplyService;
+import com.threeping.mudium.musicalreply.vo.MusicalReplyVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,7 +21,7 @@ public class MusicalReplyController {
         this.musicalReplyService = musicalReplyService;
     }
 
-    @GetMapping("{commentId}")
+    @GetMapping("/{commentId}")
     public ResponseDTO<?> findMusicalReply(@PathVariable Long commentId) {
         List<MusicalReplyDTO> list = musicalReplyService.findAllReply(commentId);
 
@@ -32,5 +30,37 @@ public class MusicalReplyController {
         responseDTO.setSuccess(true);
         responseDTO.setHttpStatus(HttpStatus.OK);
         return responseDTO;
+    }
+
+    @PostMapping("/{commentId}")
+    public ResponseDTO<?> createMusicalReply(@PathVariable Long commentId, @RequestBody MusicalReplyVO replyVO) {
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        replyDTO.setCommentId(commentId);
+        replyDTO.setContent(replyVO.getContent());
+
+        musicalReplyService.createReply(replyVO.getUserId(), replyDTO);
+
+        return ResponseDTO.ok(replyDTO);
+    }
+
+    @PutMapping("/{replyId}")
+    public ResponseDTO<?> updateMusicalReply(@PathVariable Long replyId, @RequestBody MusicalReplyVO replyVO) {
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        replyDTO.setMusicalReplyId(replyId);
+        replyDTO.setContent(replyVO.getContent());
+
+        musicalReplyService.updateReply(replyVO.getUserId(), replyDTO);
+
+        return ResponseDTO.ok(replyDTO);
+    }
+
+    @DeleteMapping("/{replyId}")
+    public ResponseDTO<?> deleteMusicalReply(@PathVariable Long replyId, @RequestBody MusicalReplyVO replyVO) {
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        replyDTO.setMusicalReplyId(replyId);
+
+        musicalReplyService.deleteReply(replyVO.getUserId(), replyDTO);
+
+        return ResponseDTO.ok(replyDTO);
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/repository/MusicalReplyRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/repository/MusicalReplyRepository.java
@@ -1,15 +1,19 @@
 package com.threeping.mudium.musicalreply.repository;
 
+import com.threeping.mudium.musicalreply.aggregate.ActiveStatus;
 import com.threeping.mudium.musicalreply.aggregate.MusicalReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MusicalReplyRepository extends JpaRepository<MusicalReply, Long> {
     @Query("SELECT mr, (SELECT u.nickname FROM UserEntity u WHERE u.userId = mr.userId) as nickName " +
             "FROM MusicalReplyEntity mr WHERE mr.CommentId = :commentId")
     List<Object[]> findAllByCommentIdOrderByCreatedAtDesc(Long commentId);
+
+    Optional<MusicalReply> findByMusicalReplyIdAndUserIdAndActiveStatus(Long replyId, Long userId, ActiveStatus activeStatus);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/service/MusicalReplyService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musicalreply/service/MusicalReplyService.java
@@ -6,4 +6,10 @@ import java.util.List;
 
 public interface MusicalReplyService {
     List<MusicalReplyDTO> findAllReply(Long commentId);
+
+    void createReply(Long userId, MusicalReplyDTO replyDTO);
+
+    void updateReply(Long userId, MusicalReplyDTO replyDTO);
+
+    void deleteReply(Long userId, MusicalReplyDTO replyDTO);
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/musicalreply/service/MusicalReplyServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/musicalreply/service/MusicalReplyServiceImplTests.java
@@ -6,6 +6,7 @@ import com.threeping.mudium.musicalboard.dto.MusicalPostDTO;
 import com.threeping.mudium.musicalboard.dto.MusicalPostListDTO;
 import com.threeping.mudium.musicalboard.service.MusicalBoardService;
 import com.threeping.mudium.musicalreply.dto.MusicalReplyDTO;
+import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,12 +24,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-@Slf4j
 class MusicalReplyServiceImplTests {
 
     private final MusicalReplyService musicalReplyService;
     private final MusicalCommentService musicalCommentService;
     private final MusicalBoardService musicalBoardService;
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     public MusicalReplyServiceImplTests(MusicalReplyService musicalReplyService,
@@ -65,17 +67,109 @@ class MusicalReplyServiceImplTests {
         musicalBoardService.createPost(musicalId, userId, postDTO);
 
         Page<MusicalPostListDTO> list = musicalBoardService.findAllPost(musicalId, pageable);
-        int size = list.getContent().size();
-        Long postId = list.getContent().get(size - 1).getPostId();
+        Long postId = list.getContent().get(0).getPostId();
 
         MusicalCommentDTO commentDTO = new MusicalCommentDTO();
         commentDTO.setContent("댓글 댓글 댓글");
         commentDTO.setPostId(postId);
         musicalCommentService.createComment(userId, commentDTO);
-
         MusicalCommentDTO savedComment = musicalCommentService.findComment(postId).get(0);
         Long commentId = savedComment.getCommentId();
 
+        // When
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        String content = "대대대대대댓글";
+        replyDTO.setCommentId(commentId);
+        replyDTO.setContent(content);
+        musicalReplyService.createReply(userId, replyDTO);
 
+        MusicalReplyDTO dto = musicalReplyService.findAllReply(commentId).get(0);
+
+        // Then
+        assertNotNull(dto, "생성된 대댓글 not null 확인");
+        assertTrue(dto.getCommentId() == commentId, "생성된 대댓글의 댓글 Id 확인");
+        assertTrue(dto.getContent().equals(content), "작성된 대댓글 내용 확인");
+        // 대댓글 trigger가 추가되면 대댓글이 생성될 경우, 게시글의 댓글 수가 증가하는지 테스트!
+    }
+
+    @DisplayName("특정 댓글에 대한 대댓글 수정")
+    @Test
+    void updateReply() {
+        // Given
+        Long userId = 1L;
+        Long musicalId = 1L;
+        MusicalPostDTO postDTO = new MusicalPostDTO();
+        postDTO.setTitle("제목");
+        postDTO.setContent("내용");
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        musicalBoardService.createPost(musicalId, userId, postDTO);
+
+        Page<MusicalPostListDTO> list = musicalBoardService.findAllPost(musicalId, pageable);
+        Long postId = list.getContent().get(0).getPostId();
+
+        MusicalCommentDTO commentDTO = new MusicalCommentDTO();
+        commentDTO.setContent("댓글 댓글 댓글");
+        commentDTO.setPostId(postId);
+        musicalCommentService.createComment(userId, commentDTO);
+        MusicalCommentDTO savedComment = musicalCommentService.findComment(postId).get(0);
+        Long commentId = savedComment.getCommentId();
+
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        String content = "대대대대대댓글";
+        replyDTO.setCommentId(commentId);
+        replyDTO.setContent(content);
+        musicalReplyService.createReply(userId, replyDTO);
+
+        String newContent = "수정 수정 수정";
+        MusicalReplyDTO createdDTO = musicalReplyService.findAllReply(commentId).get(0);
+        createdDTO.setContent(newContent);
+        musicalReplyService.updateReply(userId, createdDTO);
+
+        MusicalReplyDTO dto = musicalReplyService.findAllReply(commentId).get(0);
+
+        // Then
+        assertNotNull(dto, "수정된 대댓글 not null 확인");
+        assertTrue(dto.getCommentId() == commentId, "수정된 대댓글의 댓글 Id 확인");
+        assertTrue(dto.getContent().equals(newContent), "수정된 대댓글 내용 확인");
+    }
+
+    @DisplayName("특정 댓글에 대한 대댓글을 삭제한다.")
+    @Test
+    void deleteReply() {
+        // Given
+        Long userId = 1L;
+        Long musicalId = 1L;
+        MusicalPostDTO postDTO = new MusicalPostDTO();
+        postDTO.setTitle("제목");
+        postDTO.setContent("내용");
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        musicalBoardService.createPost(musicalId, userId, postDTO);
+
+        Page<MusicalPostListDTO> list = musicalBoardService.findAllPost(musicalId, pageable);
+        Long postId = list.getContent().get(0).getPostId();
+
+        MusicalCommentDTO commentDTO = new MusicalCommentDTO();
+        commentDTO.setContent("댓글 댓글 댓글");
+        commentDTO.setPostId(postId);
+        musicalCommentService.createComment(userId, commentDTO);
+        MusicalCommentDTO savedComment = musicalCommentService.findComment(postId).get(0);
+        Long commentId = savedComment.getCommentId();
+
+        MusicalReplyDTO replyDTO = new MusicalReplyDTO();
+        String content = "대대대대대댓글";
+        replyDTO.setCommentId(commentId);
+        replyDTO.setContent(content);
+        musicalReplyService.createReply(userId, replyDTO);
+        MusicalReplyDTO createdDTO = musicalReplyService.findAllReply(commentId).get(0);
+
+        // When
+        musicalReplyService.deleteReply(userId, createdDTO);
+        MusicalReplyDTO dto = musicalReplyService.findAllReply(commentId).get(0);
+
+        // Then
+        assertNotNull(dto, "삭제된 대댓글 not null 확인");
+        assertTrue(dto.getCommentId() == commentId, "삭제된 대댓글의 댓글 Id 확인");
+        assertTrue(dto.getContent().equals("삭제된 댓글입니다."), "삭제된 대댓글 내용 확인");
+        // 삭제된 후, 게시글 리스트에서 댓글 수 표시가 -1됐는지 확인하는 테스트 추가할 예정
     }
 }


### PR DESCRIPTION
---
name: 대댓글 CUD 기능 추가
about: 뮤지컬 게시판의 대댓글 생성, 수정, 삭제 기능을 추가했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 
대댓글 생성
<img width="589" alt="image" src="https://github.com/user-attachments/assets/b71f0eee-667c-4149-9042-93b4acd3863e">

대댓글 수정
<img width="589" alt="image" src="https://github.com/user-attachments/assets/d1e62eb6-5b7a-4706-8d87-4ef816644642">

대댓글 삭제
<img width="589" alt="image" src="https://github.com/user-attachments/assets/5096b5c6-3fef-4f8b-b595-5682b6d71c68">


## 테스트 계획 또는 완료 사항
- [x] 대댓글 생성
- [x] 대댓글 수정
- [x] 대댓글 삭제
