### PR TITLE
[문의게시글] 문의게시글 조회 기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -88,7 +88,9 @@ public enum ErrorCode {
     INVALID_BOARD_USER_ID(4002102,HttpStatus.BAD_REQUEST,"수정 권한이 없는 게시글입니다."),
     //Notice
     INVALID_NOTICE_ID(4002201,HttpStatus.BAD_REQUEST ,"잘못된 공지게시글 번호입니다." ),
-    INVALID_USER_ROLE(4002202,HttpStatus.BAD_REQUEST ,"공지 게시글은 관리자만 관리할 수 있습니다." );
+    INVALID_USER_ROLE(4002202,HttpStatus.BAD_REQUEST ,"공지 게시글은 관리자만 관리할 수 있습니다." ),
+    //Inquiry
+    NOT_FOUND_USER_INQUIRY(4012301,HttpStatus.NOT_FOUND ,"해당 문의를 찾을 수 없습니다." );
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/aggregate/entity/Inquiry.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/aggregate/entity/Inquiry.java
@@ -1,0 +1,41 @@
+package com.threeping.mudium.inquiry.aggregate.entity;
+
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "TBL_INQUIRY")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class Inquiry {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "comments")
+    private Long comments;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/aggregate/enumerate/SearchType.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/aggregate/enumerate/SearchType.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.inquiry.aggregate.enumerate;
+
+public enum SearchType {
+    TITLE,
+    CONTENT
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/controller/InquiryController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/controller/InquiryController.java
@@ -1,0 +1,50 @@
+package com.threeping.mudium.inquiry.controller;
+
+import com.threeping.mudium.inquiry.aggregate.enumerate.SearchType;
+import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.inquiry.dto.InquiryDetailDTO;
+import com.threeping.mudium.inquiry.dto.InquiryListDTO;
+import com.threeping.mudium.inquiry.service.InquiryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/inquiry")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @Autowired
+    InquiryController(InquiryService inquiryService){
+        this.inquiryService = inquiryService;
+    }
+
+    @GetMapping("{userId}")
+    private ResponseDTO<?> viewInquiryPage(
+            @PathVariable Long userId,
+            @RequestParam(required = false) SearchType searchType,
+            @RequestParam(required = false) String searchQuery,
+            Pageable pageable){
+
+        Page<InquiryListDTO> inquiryPage;
+
+        if(searchType != null && searchQuery != null && !searchQuery.trim().isEmpty()) {
+            inquiryPage = inquiryService.viewSearchedInquiryList(pageable,searchType,searchQuery,userId);
+        } else {
+            inquiryPage = inquiryService.viewInquiryList(pageable,userId);
+        }
+
+        return ResponseDTO.ok(inquiryPage);
+    }
+
+    @GetMapping("{userId}/{inquiryId}")
+    private ResponseDTO<?> viewDetailInquiry(@PathVariable Long userId,
+                                          @PathVariable Long inquiryId){
+        InquiryDetailDTO inquiryDetail = inquiryService.viewInquiry(userId,inquiryId);
+        return ResponseDTO.ok(inquiryDetail);
+    }
+
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/dto/InquiryDetailDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/dto/InquiryDetailDTO.java
@@ -1,0 +1,20 @@
+package com.threeping.mudium.inquiry.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class InquiryDetailDTO {
+    private Long inquiryId;
+    private String title;
+    private String content;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+    private Long comments;
+    private Long userId;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/dto/InquiryListDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/dto/InquiryListDTO.java
@@ -1,0 +1,17 @@
+package com.threeping.mudium.inquiry.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class InquiryListDTO {
+    private Long inquiryId;
+    private String title;
+    private Long userId;
+    private Timestamp createdAt;
+    private Long comments;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/repository/InquiryRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,19 @@
+package com.threeping.mudium.inquiry.repository;
+
+import com.threeping.mudium.inquiry.aggregate.entity.Inquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InquiryRepository extends JpaRepository<Inquiry,Long> {
+
+    Page<Inquiry> findByTitleContainingAndUser_UserId(String title, Long userId, Pageable pageable);
+
+    Page<Inquiry> findByContentContainingAndUser_UserId(String content, Long userId, Pageable pageable);
+
+    Page<Inquiry> findByUser_userId(Long userId, Pageable inquiryPageable);
+
+    Inquiry findByInquiryIdAndUser_userId(Long inquiryId, Long userId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/service/InquiryService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/service/InquiryService.java
@@ -1,0 +1,15 @@
+package com.threeping.mudium.inquiry.service;
+
+import com.threeping.mudium.inquiry.aggregate.enumerate.SearchType;
+import com.threeping.mudium.inquiry.dto.InquiryDetailDTO;
+import com.threeping.mudium.inquiry.dto.InquiryListDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InquiryService {
+    Page<InquiryListDTO> viewSearchedInquiryList(Pageable pageable, SearchType searchType, String searchQuery, Long userId);
+
+    Page<InquiryListDTO> viewInquiryList(Pageable pageable, Long userId);
+
+    InquiryDetailDTO viewInquiry(Long userId, Long inquiryId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/inquiry/service/InquiryServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/inquiry/service/InquiryServiceImpl.java
@@ -1,0 +1,106 @@
+package com.threeping.mudium.inquiry.service;
+
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.inquiry.aggregate.entity.Inquiry;
+import com.threeping.mudium.inquiry.aggregate.enumerate.SearchType;
+import com.threeping.mudium.inquiry.dto.InquiryDetailDTO;
+import com.threeping.mudium.inquiry.dto.InquiryListDTO;
+import com.threeping.mudium.inquiry.repository.InquiryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+// 관리자용 전체 조회 메서드 추가 예정
+
+@Slf4j
+@Service
+public class InquiryServiceImpl implements InquiryService{
+
+    private final InquiryRepository inquiryRepository;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    InquiryServiceImpl(InquiryRepository inquiryRepository,
+                       ModelMapper modelMapper){
+        this.inquiryRepository = inquiryRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    public Page<InquiryListDTO> viewSearchedInquiryList(Pageable pageable, SearchType searchType, String searchQuery, Long userId) {
+        int pageNumber = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable inquiryPageable = PageRequest.of(pageNumber,pageSize,pageSort);
+        if (searchType.equals(SearchType.TITLE)) {
+            return searchInquiryByTitle(searchQuery,userId,inquiryPageable);
+        } else if (searchType.equals(SearchType.CONTENT)) {
+            return searchInquiryByContent(searchQuery,userId, inquiryPageable);
+        }
+        return null;
+    }
+
+    @Override
+    public Page<InquiryListDTO> viewInquiryList(Pageable pageable, Long userId) {
+        int pageNumber = pageable.getPageNumber() > 0 ? pageable.getPageNumber() - 1 : 0;
+        int pageSize = pageable.getPageSize();
+        Sort pageSort = Sort.by("createdAt").descending();
+        Pageable inquiryPageable = PageRequest.of(pageNumber,pageSize,pageSort);
+
+        Page<Inquiry> inquiries = inquiryRepository.findByUser_userId(userId,inquiryPageable);
+
+        List<InquiryListDTO> inquiryListDTOList = inquiries.stream()
+                .map(inquiry -> {
+                    InquiryListDTO inquiryListDTO = modelMapper.map(inquiry,InquiryListDTO.class);
+                    return inquiryListDTO;
+                })
+                .collect(Collectors.toList());
+        log.info("inquyrDTOLIst:{}",inquiryListDTOList);
+        Page<InquiryListDTO> inquiryListDTOS = new PageImpl<>(inquiryListDTOList,inquiryPageable,inquiries.getTotalElements());
+        log.info("inquiryLISTDTO:{}",inquiryListDTOS);
+        return inquiryListDTOS;
+    }
+
+    @Override
+    public InquiryDetailDTO viewInquiry(Long userId, Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findByInquiryIdAndUser_userId(inquiryId,userId);
+        InquiryDetailDTO inquiryDetailDTO = null;
+        try {
+             inquiryDetailDTO = new InquiryDetailDTO(inquiry.getInquiryId(),
+                    inquiry.getTitle(),
+                    inquiry.getContent(),
+                    inquiry.getCreatedAt(),
+                    inquiry.getUpdatedAt(),
+                    inquiry.getComments(),
+                    inquiry.getUser().getUserId());
+        } catch (Exception e){
+            throw new CommonException(ErrorCode.NOT_FOUND_USER_INQUIRY);
+        }
+        return inquiryDetailDTO;
+    }
+
+    public Page<InquiryListDTO> searchInquiryByTitle(String title,Long userId, Pageable pageable) {
+        return inquiryRepository.findByTitleContainingAndUser_UserId(title,userId, pageable).map(this::convertToDTO);
+    }
+
+    public Page<InquiryListDTO> searchInquiryByContent(String content, Long userId, Pageable pageable) {
+        return inquiryRepository.findByContentContainingAndUser_UserId(content, userId, pageable).map(this::convertToDTO);
+    }
+
+    private InquiryListDTO convertToDTO(Inquiry inquiry){
+        InquiryListDTO inquiryListDTO = new InquiryListDTO();
+        inquiryListDTO.setTitle(inquiry.getTitle());
+        inquiryListDTO.setComments(inquiry.getComments());
+        inquiryListDTO.setCreatedAt(inquiry.getCreatedAt());
+        inquiryListDTO.setInquiryId(inquiry.getInquiryId());
+        inquiryListDTO.setUserId(inquiry.getUser().getUserId());
+        return inquiryListDTO;
+    }
+
+}

--- a/MUDIUM/src/test/java/com/threeping/mudium/inquiry/service/InquiryServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/inquiry/service/InquiryServiceImplTests.java
@@ -1,0 +1,58 @@
+package com.threeping.mudium.inquiry.service;
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.inquiry.dto.InquiryDetailDTO;
+import com.threeping.mudium.inquiry.dto.InquiryListDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+class InquiryServiceImplTests {
+
+    private final InquiryService inquiryService;
+    @Autowired
+    InquiryServiceImplTests(InquiryService inquiryService) {
+        this.inquiryService = inquiryService;
+    }
+
+    @DisplayName("게시글 리스트를 페이지로 조회한다.")
+    @Test
+    void inquiryPageViewTest(){
+        Pageable pageable = PageRequest.of(1,10, Sort.by("createdAt").descending());
+        Long memberId = 1L;
+        Page<InquiryListDTO> inquiryDTOPage = inquiryService.viewInquiryList(pageable,memberId);
+
+        assertNotNull(inquiryDTOPage, "조회된 페이지는 null이 아니다.");
+        log.info("inquiryDTOPage: {}",inquiryDTOPage);
+        assertTrue(inquiryDTOPage.hasContent(), "조회된 페이지는 내용이 있다.");
+        assertEquals(10, inquiryDTOPage.getSize(), "페이지 크기는 10이다.");
+
+    }
+
+    @DisplayName("게시글 상세 정보를 조회한다.")
+    @Test
+    void inquiryDetailViewTest(){
+        Long inquiryId = 1L;
+        Long invalidInquiryId = -1L;
+        Long memberId = 1L;
+        InquiryDetailDTO inquiryDetailDTO = inquiryService.viewInquiry(memberId,inquiryId);
+
+        assertNotNull(inquiryDetailDTO,"조회된 게시글은 null이 아니다.");
+        assertEquals(inquiryId,inquiryDetailDTO.getInquiryId(),"조회된 게시글 ID는 요청된 ID와 일치한다.");
+        Exception exception = assertThrows(CommonException.class,
+                ()->inquiryService.viewInquiry(memberId,invalidInquiryId));
+        assertEquals("해당 문의를 찾을 수 없습니다.",exception.getMessage());
+    }
+}


### PR DESCRIPTION
---
name: [문의게시글] 문의게시글 조회 기능 추가
about: 
1) 문의게시글 목록 조회 - 페이징
2) 문의게시글 상세 내용 조회

title: #75 
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 문의게시글은 회원이 자신이 쓴 게시글만 목록에서 볼 수 있게 처리했습니다. 관리자는 모든 문의를 볼 수 있지만, 추후 구현 예정입니다!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/b05ffb81-0ecf-4d55-b04a-6157c733bc09)
![image](https://github.com/user-attachments/assets/d2a962af-ad6b-48e3-ad62-152a4eea536d)


## 테스트 계획 또는 완료 사항
- [x] 포스트맨
- [x] 테스트코드
