### PR TITLE
[자유게시글 대댓글] 자유게시글 대댓글 조회 및 생성 기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/aggregate/entity/BoardReply.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/aggregate/entity/BoardReply.java
@@ -1,0 +1,43 @@
+package com.threeping.mudium.boardreply.aggregate.entity;
+
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "TBL_BOARD_REPLY")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class BoardReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_reply_id")
+    private Long boardReplyId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "created_at")
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    private Timestamp updatedAt;
+
+    @Column(name = "active_status")
+    @Enumerated(EnumType.STRING)
+    private ActiveStatus activeStatus;
+
+    @Column(name = "board_comment_id")
+    private Long boardCommentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/controller/BoardReplyController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/controller/BoardReplyController.java
@@ -1,0 +1,37 @@
+package com.threeping.mudium.boardreply.controller;
+
+import com.threeping.mudium.boardreply.dto.BoardReplyDTO;
+import com.threeping.mudium.boardreply.service.BoardReplyService;
+import com.threeping.mudium.common.ResponseDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/board-reply")
+public class BoardReplyController {
+
+    private final BoardReplyService boardReplyService;
+
+    @Autowired
+    BoardReplyController(BoardReplyService boardReplyService) {
+        this.boardReplyService = boardReplyService;
+    }
+
+    @GetMapping("{boardCommentId}")
+    private ResponseDTO<?> viewBoardReply(@PathVariable Long boardCommentId){
+        List<BoardReplyDTO> boardReplies = boardReplyService.viewBoardReply(boardCommentId);
+
+        return ResponseDTO.ok(boardReplies);
+    }
+
+    @PostMapping("{boardCommentId}")
+    private ResponseDTO<?> createBoardReply(@PathVariable Long boardCommentId,
+                                            @RequestBody BoardReplyDTO boardReplyDTO){
+        boardReplyDTO.setBoardCommentId(boardCommentId);
+        boardReplyService.createBoardReply(boardReplyDTO);
+
+        return ResponseDTO.ok(null);
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/dto/BoardReplyDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/dto/BoardReplyDTO.java
@@ -1,0 +1,19 @@
+package com.threeping.mudium.boardreply.dto;
+
+import lombok.*;
+
+import java.sql.Timestamp;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class BoardReplyDTO {
+    private Long boardReplyId;
+    private String content;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+    private Long boardCommentId;
+    private Long userId;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/repository/BoardReplyRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/repository/BoardReplyRepository.java
@@ -1,0 +1,12 @@
+package com.threeping.mudium.boardreply.repository;
+
+import com.threeping.mudium.boardreply.aggregate.entity.BoardReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardReplyRepository extends JpaRepository<BoardReply,Long> {
+    List<BoardReply> findByBoardCommentId(Long boardCommentId);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/service/BoardReplyService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/service/BoardReplyService.java
@@ -1,0 +1,11 @@
+package com.threeping.mudium.boardreply.service;
+
+import com.threeping.mudium.boardreply.dto.BoardReplyDTO;
+
+import java.util.List;
+
+public interface BoardReplyService {
+    List<BoardReplyDTO> viewBoardReply(Long boardCommentId);
+
+    void createBoardReply(BoardReplyDTO boardReplyDTO);
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/boardreply/service/BoardReplyServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/boardreply/service/BoardReplyServiceImpl.java
@@ -1,0 +1,50 @@
+package com.threeping.mudium.boardreply.service;
+
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
+import com.threeping.mudium.boardreply.aggregate.entity.BoardReply;
+import com.threeping.mudium.boardreply.dto.BoardReplyDTO;
+import com.threeping.mudium.boardreply.repository.BoardReplyRepository;
+import com.threeping.mudium.user.aggregate.entity.UserEntity;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+
+@Service
+public class BoardReplyServiceImpl implements BoardReplyService{
+
+    private final BoardReplyRepository boardReplyRepository;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    BoardReplyServiceImpl(BoardReplyRepository boardReplyRepository, ModelMapper modelMapper){
+        this.boardReplyRepository = boardReplyRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    @Override
+    public List<BoardReplyDTO> viewBoardReply(Long boardCommentId) {
+        List<BoardReply> boardReplyList = boardReplyRepository.findByBoardCommentId(boardCommentId);
+        List<BoardReplyDTO> boardReplyDTOS = boardReplyList.stream()
+                .map(boardReply -> modelMapper.map(boardReply,BoardReplyDTO.class)).toList();
+
+        return boardReplyDTOS;
+    }
+
+    @Override
+    public void createBoardReply(BoardReplyDTO boardReplyDTO) {
+        BoardReply boardReply = new BoardReply();
+        UserEntity user = new UserEntity();
+        user.setUserId(boardReplyDTO.getUserId());
+        boardReply.setBoardCommentId(boardReplyDTO.getBoardCommentId());
+        boardReply.setContent(boardReplyDTO.getContent());
+        boardReply.setUser(user);
+        boardReply.setActiveStatus(ActiveStatus.ACTIVE);
+        boardReply.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        boardReplyRepository.save(boardReply);
+    }
+}

--- a/MUDIUM/src/test/java/com/threeping/mudium/boardcomment/service/BoardCommentServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/boardcomment/service/BoardCommentServiceImplTests.java
@@ -82,7 +82,6 @@ class BoardCommentServiceImplTests {
         RegistBoardDTO registBoardDTO = new RegistBoardDTO(userId,title,content);
         boardService.createBoard(registBoardDTO);
         Board savedBoard = boardRepository.findAll(Sort.by("createdAt").descending()).get(0);
-        log.info("{}",savedBoard);
         String commentContent = "테스트 댓글 내용";
         BoardCommentDTO boardCommentDTO = new BoardCommentDTO();
         boardCommentDTO.setBoardId(savedBoard.getBoardId());

--- a/MUDIUM/src/test/java/com/threeping/mudium/boardreply/service/BoardReplyServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/boardreply/service/BoardReplyServiceImplTests.java
@@ -1,0 +1,136 @@
+package com.threeping.mudium.boardreply.service;
+
+import com.threeping.mudium.board.aggregate.entity.Board;
+import com.threeping.mudium.board.aggregate.enumerate.ActiveStatus;
+import com.threeping.mudium.board.dto.RegistBoardDTO;
+import com.threeping.mudium.board.repository.BoardRepository;
+import com.threeping.mudium.board.service.BoardService;
+import com.threeping.mudium.boardcomment.aggregate.BoardComment;
+import com.threeping.mudium.boardcomment.dto.BoardCommentDTO;
+import com.threeping.mudium.boardcomment.repository.BoardCommentRepository;
+import com.threeping.mudium.boardcomment.service.BoardCommentService;
+import com.threeping.mudium.boardreply.aggregate.entity.BoardReply;
+import com.threeping.mudium.boardreply.dto.BoardReplyDTO;
+import com.threeping.mudium.boardreply.repository.BoardReplyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BoardReplyServiceImplTests {
+
+    private final BoardReplyService boardReplyService;
+    private final BoardService boardService;
+    private final BoardRepository boardRepository;
+    private final BoardCommentService boardCommentService;
+    private final BoardCommentRepository boardCommentRepository;
+    @Autowired
+    private BoardReplyRepository boardReplyRepository;
+
+    @Autowired
+    BoardReplyServiceImplTests(BoardReplyService boardReplyService,
+                               BoardService boardService,
+                               BoardRepository boardRepository,
+                               BoardCommentService boardCommentService,
+                               BoardCommentRepository boardCommentRepository){
+        this.boardReplyService = boardReplyService;
+        this.boardService = boardService;
+        this.boardRepository = boardRepository;
+        this.boardCommentService = boardCommentService;
+        this.boardCommentRepository = boardCommentRepository;
+    }
+
+    @DisplayName("자유게시글 대댓글을 조회한다.")
+    @Test
+    void viewBoardReplyTest(){
+        String boardTitle = "테스트 제목";
+        String boardContent = "테스트 내용";
+        Long userId = 1L;
+        RegistBoardDTO registBoardDTO = new RegistBoardDTO(userId,boardTitle,boardContent);
+        boardService.createBoard(registBoardDTO);
+        Board savedBoard = boardRepository.findAll(Sort.by("createdAt").descending()).get(0);
+        String commentContent = "테스트 댓글 내용";
+        BoardCommentDTO boardCommentDTO = new BoardCommentDTO();
+        boardCommentDTO.setBoardId(savedBoard.getBoardId());
+        boardCommentDTO.setUserId(userId);
+        boardCommentDTO.setContent(commentContent);
+        boardCommentDTO.setActiveStatus(ActiveStatus.ACTIVE);
+        boardCommentDTO.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        boardCommentService.createBoardComment(boardCommentDTO);
+
+        BoardComment boardComment = boardCommentRepository
+                .findByBoardIdAndActiveStatus(
+                        savedBoard.getBoardId(), ActiveStatus.ACTIVE,
+                        PageRequest.of(0,
+                                10,
+                                Sort.by("createdAt").descending())).getContent().get(0);
+        String content = "테스트 대댓글 내용";
+
+        BoardReplyDTO boardReplyDTO = new BoardReplyDTO();
+        boardReplyDTO.setBoardCommentId(boardComment.getBoardCommentId());
+        boardReplyDTO.setContent(content);
+        boardReplyDTO.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        boardReplyDTO.setUserId(userId);
+        boardReplyService.createBoardReply(boardReplyDTO);
+
+        Long newRelyId = boardReplyService.viewBoardReply(boardComment.getBoardCommentId()).get(0).getBoardReplyId();
+
+        List<BoardReplyDTO> boardReplyDTOs = boardReplyService.viewBoardReply(boardComment.getBoardCommentId());
+
+        assertEquals(newRelyId,boardReplyDTOs.get(0).getBoardReplyId());
+        assertEquals(content,boardReplyDTOs.get(0).getContent());
+
+    }
+
+    @DisplayName("자유게시글 대댓글을 작성한다.")
+    @Test
+    void createBoardReplyTest(){
+        String boardTitle = "테스트 제목";
+        String boardContent = "테스트 내용";
+        Long userId = 1L;
+        RegistBoardDTO registBoardDTO = new RegistBoardDTO(userId,boardTitle,boardContent);
+        boardService.createBoard(registBoardDTO);
+        Board savedBoard = boardRepository.findAll(Sort.by("createdAt").descending()).get(0);
+        String commentContent = "테스트 댓글 내용";
+        BoardCommentDTO boardCommentDTO = new BoardCommentDTO();
+        boardCommentDTO.setBoardId(savedBoard.getBoardId());
+        boardCommentDTO.setUserId(userId);
+        boardCommentDTO.setContent(commentContent);
+        boardCommentDTO.setActiveStatus(ActiveStatus.ACTIVE);
+        boardCommentDTO.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        boardCommentService.createBoardComment(boardCommentDTO);
+
+        BoardComment boardComment = boardCommentRepository
+                .findByBoardIdAndActiveStatus(
+                        savedBoard.getBoardId(), ActiveStatus.ACTIVE,
+                        PageRequest.of(0,
+                                10,
+                                Sort.by("createdAt").descending())).getContent().get(0);
+        String content = "테스트 대댓글 내용";
+
+        BoardReplyDTO boardReplyDTO = new BoardReplyDTO();
+        boardReplyDTO.setBoardCommentId(boardComment.getBoardCommentId());
+        boardReplyDTO.setContent(content);
+        boardReplyDTO.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        boardReplyDTO.setUserId(userId);
+        boardReplyService.createBoardReply(boardReplyDTO);
+
+        Long newRelyId = boardReplyService.viewBoardReply(boardComment.getBoardCommentId()).get(0).getBoardReplyId();
+        BoardReply boardReply = boardReplyRepository.findById(newRelyId).orElseThrow();
+
+        assertNotNull(boardReply);
+        assertEquals(content,boardReply.getContent());
+
+    }
+
+}


### PR DESCRIPTION
---
name: [자유게시글 대댓글] 자유게시글 대댓글 조회 및 생성 기능 추가
about: 대댓글을 작성하고 조회하는 기능을 추가함
title: #89
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 테스트코드를 작성하는 좋은 방법이 있으면 코멘트 부탁드립니다!!!!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/6f0a1e1b-caf5-43b0-923d-acb25bdd7350)

## 테스트 계획 또는 완료 사항
- [x] 테스트코드
- [x] 포스트맨을 통한 확인
