### PR TITLE
ADD: 뮤지컬과 공연 정보를 저장하는 API 로직 수정 및 공연 순위를 저장하는 API 기능 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/common/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
     SCOPE_NOT_FOUND(4041003, HttpStatus.NOT_FOUND, "별점이 존재하지 않습니다."),
 
     // Musical
+    JAXB_MANAGER_ERROR(5001300, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB MANAGER 생성에 실패했습니다."),
     JAXB_CONTEXT_ERROR(5001301, HttpStatus.INTERNAL_SERVER_ERROR, "JAXB CONTEXT 생성에 실패했습니다."),
     API_LIST_BAD_REQUEST(4001302, HttpStatus.BAD_REQUEST, "공연리스트 API 통신에 실패했습니다."),
     API_DETAIL_BAD_REQUEST(4001303, HttpStatus.BAD_REQUEST, "상세정보 API 통신에 실패했습니다."),
@@ -82,6 +83,7 @@ public enum ErrorCode {
     MISSING_REQUIRED_CONTENT(4001308, HttpStatus.BAD_REQUEST, "필수 내용이 누락되었습니다."),
     NOT_FOUND_COMMENT(4001309, HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다."),
     NOT_FOUND_REPLY(4001310, HttpStatus.NOT_FOUND, "대댓글이 존재하지 않습니다."),
+    API_RANK_BAD_REQUEST(4001310, HttpStatus.BAD_REQUEST, "공연 순위 API 통신에 실패했습니다.."),
 
 
     //Board

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/dto/MusicalDTO.java
@@ -1,15 +1,15 @@
 package com.threeping.mudium.musical.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
+@ToString
 public class MusicalDTO {
+
+    private Long musicalId;
 
     private String title;
 

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/JAXBManager.java
@@ -6,6 +6,8 @@ import com.threeping.mudium.musical.dto.MusicalItem;
 import com.threeping.mudium.musical.dto.MusicalListResponse;
 import com.threeping.mudium.performance.dto.PerformanceItem;
 import com.threeping.mudium.performance.dto.PerformanceResponse;
+import com.threeping.mudium.performance.dto.RankItem;
+import com.threeping.mudium.performance.dto.RankResponse;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
@@ -20,19 +22,22 @@ public class JAXBManager {
     private static final JAXBManager INSTANCE = new JAXBManager();
     private final JAXBContext musicalContext;
     private final JAXBContext performanceContext;
+    private final JAXBContext rankContext;
 
     private JAXBManager() {
         try {
             this.musicalContext = JAXBContext.newInstance(
                     MusicalListResponse.class,
                     MusicalItem.class);
-            log.info("JAXBManager MusicalList Mapping Context 싱글톤 객체 생성 성공");
             this.performanceContext = JAXBContext.newInstance(
                     PerformanceResponse.class,
                     PerformanceItem.class);
-            log.info("JAXBManager Performance Mapping Context 싱글톤 객체 생성 성공");
+            this.rankContext = JAXBContext.newInstance(
+                    RankResponse.class,
+                    RankItem.class);
+            log.info("JAXBManager 싱글톤 객체 생성 성공");
         } catch (JAXBException e) {
-            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+            throw new CommonException(ErrorCode.JAXB_MANAGER_ERROR);
         }
     }
 
@@ -48,6 +53,10 @@ public class JAXBManager {
 
     public <T> T unmarshalPerformance(String xml, Class<T> clazz) throws JAXBException {
         return unmarshal(xml, clazz, performanceContext);
+    }
+
+    public <T> T unmarshalRank(String xml, Class<T> clazz) throws JAXBException {
+        return unmarshal(xml, clazz, rankContext);
     }
 
     private <T> T unmarshal(String xml, Class<T> clazz, JAXBContext context) throws JAXBException {

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalAPIClient.java
@@ -16,6 +16,9 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,8 +40,11 @@ public class MusicalAPIClient {
     }
 
     public List<MusicalItem> fetchMusicalList() {
-        String startDate = "20220101";
-        String endDate = "20240930";
+        log.info("Fetching musical list");
+        // test를 위해서 줄입니다..
+        String startDate = "20240101";
+        String endDate = "20241231";
+        log.info("endDate: {}", endDate);
         int cPage = 1;
         List<MusicalItem> allMusicals = new ArrayList<>();
 
@@ -96,5 +102,11 @@ public class MusicalAPIClient {
         } catch (JAXBException e) {
             throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
         }
+    }
+
+    private String timeConverter(LocalDateTime now) {
+        DateTimeFormatter sdf = DateTimeFormatter.ofPattern("yyyyMMdd");
+        String format = now.format(sdf);
+        return format;
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalService.java
@@ -10,8 +10,6 @@ import org.springframework.data.domain.Pageable;
 public interface MusicalService {
     MusicalDTO findMusicalDetail(Long musicId);
 
-    MusicalDTO findMusicalByMusicalId(Long musicalId);
-
     Page<MusicalListDTO> findByName(String title,Pageable pageable);
 
     MusicalDTO findMusicalDetailByName(String title);

--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
@@ -72,6 +72,7 @@ public class MusicalServiceImpl implements MusicalService {
                 .map(musical -> {
                     MusicalListDTO dto = new MusicalListDTO();
                     dto.setMusicalId(musical.getMusicalId());
+                    dto.setMusicalId(musical.getMusicalId());
                     dto.setPoster(musical.getPoster());
                     dto.setTitle(musical.getTitle());
                     dto.setAverageScope(averageScopes.get(musical.getMusicalId()));
@@ -95,6 +96,7 @@ public class MusicalServiceImpl implements MusicalService {
         MusicalDTO musicalDTO = new MusicalDTO();
         Musical musical = musicalRepository.findMusicalByMusicalId(musicalId)
                 .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_ID));
+        musicalDTO.setMusicalId(musical.getMusicalId());
         musicalDTO.setTitle(musical.getTitle());
         musicalDTO.setRating(musical.getRating());
         musicalDTO.setPoster(musical.getPoster());
@@ -109,25 +111,11 @@ public class MusicalServiceImpl implements MusicalService {
     }
 
     @Override
-    public MusicalDTO findMusicalByMusicalId(Long musicalId) {
-        Musical musical = musicalRepository.findMusicalByMusicalId(musicalId)
-                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_ID));
-        MusicalDTO musicalDTO = new MusicalDTO();
-        musicalDTO.setTitle(musical.getTitle());
-        musicalDTO.setReviewVideos(musical.getReviewVideo());
-        musicalDTO.setPoster(musical.getPoster());
-        musicalDTO.setProduction(musical.getProduction());
-        musicalDTO.setSynopsys(musical.getSynopsys());
-        musicalDTO.setViewCount(musical.getViewCount());
-        musicalDTO.setRating(musical.getRating());
-        return musicalDTO;
-    }
-
-    @Override
     public MusicalDTO findMusicalDetailByName(String title) {
         Musical musical = musicalRepository.findMusicalByExactTitle(title)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_MUSICAL));
         MusicalDTO musicalDTO = new MusicalDTO();
+        musicalDTO.setMusicalId(musical.getMusicalId());
         musicalDTO.setTitle(musical.getTitle());
         musicalDTO.setReviewVideos(musical.getReviewVideo());
         musicalDTO.setPoster(musical.getPoster());

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/PerformanceRank.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/PerformanceRank.java
@@ -1,0 +1,43 @@
+package com.threeping.mudium.performance.aggregate;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity(name = "rankEntity")
+@Table(name = "TBL_PERFORMANCE_RANK")
+public class PerformanceRank {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "performance_rank_id")
+    private Long rankId;
+
+    @Column(name = "start_date")
+    private Timestamp startDate;
+
+    @Column(name = "end_date")
+    private Timestamp endDate;
+
+    @Column(name = "rank_type")
+    @Enumerated(EnumType.STRING)
+    private RankType rankType;
+
+    @Column(name = "rank")
+    private Integer rank;
+
+    @Column(name = "musical_id")
+    private Long musicalId;
+
+    @Column(name = "performance_id")
+    private Long performanceId;
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/RankType.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/aggregate/RankType.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.performance.aggregate;
+
+public enum RankType {
+    DAILY,
+    MONTHLY
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceDTO.java
@@ -11,6 +11,8 @@ import java.sql.Timestamp;
 @ToString
 public class PerformanceDTO {
 
+    private Long performanceId;
+
     private String theater;
 
     private String region;
@@ -18,5 +20,7 @@ public class PerformanceDTO {
     private Timestamp startDate;
 
     private Timestamp endDate;
+
+    private Long musicalId;
 
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/RankItem.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/RankItem.java
@@ -1,0 +1,24 @@
+package com.threeping.mudium.performance.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.Setter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public class RankItem {
+
+    @XmlElement(name = "rnum")
+    private Integer Rank;
+
+    @XmlElement(name = "prfnm")
+    private String title;
+
+    @XmlElement(name = "area")
+    private String area;
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/RankResponse.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/RankResponse.java
@@ -1,0 +1,24 @@
+package com.threeping.mudium.performance.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@XmlRootElement(name = "boxofs")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@Setter
+public class RankResponse {
+
+    @XmlElement(name = "basedate")
+    private String baseDate;
+
+    @XmlElement(name = "boxof")
+    private List<RankItem> rankItems;
+
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRankRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRankRepository.java
@@ -1,0 +1,9 @@
+package com.threeping.mudium.performance.repository;
+
+import com.threeping.mudium.performance.aggregate.PerformanceRank;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PerformanceRankRepository extends JpaRepository<PerformanceRank, Long> {
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
@@ -2,6 +2,8 @@ package com.threeping.mudium.performance.repository;
 
 import com.threeping.mudium.performance.aggregate.Performance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +12,6 @@ import java.util.Optional;
 @Repository
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
     Optional<Performance> findPerformanceByPerformanceId(Long performanceId);
-    Optional<Performance> findPerformanceByMusicalIdAndRegion(Long musicalId, String region);
     List<Performance> findAllByMusicalId(Long musicalId);
+    Optional<Performance> findPerformanceByMusicalIdAndRegion(Long musicalId, String region);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceService.java
@@ -4,7 +4,10 @@ import com.threeping.mudium.musical.aggregate.Musical;
 import com.threeping.mudium.performance.dto.PerformanceDTO;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceService {
     List<PerformanceDTO> findPerformances(Long musicalId);
+
+    PerformanceDTO findPerformanceByMusicalIdAndRegion(Long musicalId, String region);
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class PerformanceServiceImpl implements PerformanceService {
 
     private final PerformanceRepository performanceRepository;
@@ -23,7 +24,7 @@ public class PerformanceServiceImpl implements PerformanceService {
         this.performanceRepository = performanceRepository;
     }
 
-    @Transactional
+
     @Override
     public List<PerformanceDTO> findPerformances(Long musicalId) {
         List<Performance> performanceList = performanceRepository.findAllByMusicalId(musicalId);
@@ -40,5 +41,21 @@ public class PerformanceServiceImpl implements PerformanceService {
                     return dto;
                 }).collect(Collectors.toList());
         return dtoList;
+    }
+
+    @Override
+    public PerformanceDTO findPerformanceByMusicalIdAndRegion(Long musicalId, String region) {
+        Performance performance = performanceRepository.findPerformanceByMusicalIdAndRegion(musicalId, region)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_MUSICAL_ID));
+
+        PerformanceDTO dto = new PerformanceDTO();
+        dto.setPerformanceId(performance.getPerformanceId());
+        dto.setMusicalId(performance.getMusicalId());
+        dto.setRegion(region);
+        dto.setTheater(performance.getTheater());
+        dto.setEndDate(performance.getEndDate());
+        dto.setStartDate(performance.getStartDate());
+
+        return dto;
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIClient.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIClient.java
@@ -1,0 +1,98 @@
+package com.threeping.mudium.performance.service;
+
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.service.JAXBManager;
+import com.threeping.mudium.performance.dto.RankResponse;
+import jakarta.xml.bind.JAXBException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@Slf4j
+public class RankAPIClient {
+
+    @Value("${kopis.api.key}")
+    private String apiKey;
+
+    @Value("${kopis.api.rankurl}")
+    private String baseUrl;
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public RankAPIClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public  RankResponse fetchMonthRank() {
+        String Date = timeConverter(LocalDateTime.now());
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .queryParam("service", apiKey)
+                .queryParam("ststype", "month")
+                .queryParam("date", Date)
+                .queryParam("catecode", "GGGA")
+                .toUriString();
+
+        RankResponse rankResponse = null;
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            log.info("정보 확인: " + response);
+            rankResponse = parseXmlResponse(response);
+            log.info("매핑된 객체 확인: " + rankResponse.getBaseDate() + "<- baseDate");
+            log.info("item 하나 확인(제목): " +rankResponse.getRankItems().get(0).getTitle());
+        } catch (RestClientException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+        return rankResponse;
+    }
+
+    public RankResponse fetchDayRank() {
+        String Date = timeConverter(LocalDateTime.now());
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .queryParam("service", apiKey)
+                .queryParam("ststype", "day")
+                .queryParam("date", Date)
+                .queryParam("catecode", "GGGA")
+                .toUriString();
+        log.info("일별 순위 url end point: " + url);
+
+        RankResponse rankResponse = null;
+        try {
+            String response = restTemplate.getForObject(url, String.class);
+            log.info("일별 순위 정보 확인: " + response);
+            rankResponse = parseXmlResponse(response);
+        } catch (RestClientException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+        return rankResponse;
+    }
+
+    private RankResponse parseXmlResponse(String response) {
+        try {
+            RankResponse rankResponse = JAXBManager.getInstance().unmarshalRank(response, RankResponse.class);
+            return rankResponse;
+        } catch (JAXBException e) {
+            throw new CommonException(ErrorCode.JAXB_CONTEXT_ERROR);
+        }
+    }
+
+    private String timeConverter(LocalDateTime time) {
+        LocalDateTime previousDay = time.minusDays(1);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        String date = previousDay.format(formatter);
+
+        log.info("변환된 date 확인 (하루 전): {}", date);
+        return date;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIService.java
@@ -1,0 +1,6 @@
+package com.threeping.mudium.performance.service;
+
+public interface RankAPIService {
+    public void updateMonthData();
+    public void updateDayData();
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/RankAPIServiceImpl.java
@@ -1,0 +1,271 @@
+package com.threeping.mudium.performance.service;
+
+import com.threeping.mudium.common.exception.CommonException;
+import com.threeping.mudium.common.exception.ErrorCode;
+import com.threeping.mudium.musical.dto.MusicalDTO;
+import com.threeping.mudium.musical.service.MusicalService;
+import com.threeping.mudium.performance.aggregate.PerformanceRank;
+import com.threeping.mudium.performance.aggregate.RankType;
+import com.threeping.mudium.performance.dto.PerformanceDTO;
+import com.threeping.mudium.performance.dto.RankItem;
+import com.threeping.mudium.performance.dto.RankResponse;
+import com.threeping.mudium.performance.repository.PerformanceRankRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+
+@Service
+@Slf4j
+public class RankAPIServiceImpl implements RankAPIService {
+
+    private final PerformanceRankRepository performanceRankRepository;
+    private final MusicalService musicalService;
+    private final RankAPIClient rankAPIClient;
+    private final PerformanceService performanceService;
+
+    public RankAPIServiceImpl(PerformanceRankRepository performanceRankRepository,
+                              PerformanceService performanceService,
+                              MusicalService musicalService,
+                              RankAPIClient rankAPIClient) {
+        this.performanceRankRepository = performanceRankRepository;
+        this.performanceService = performanceService;
+        this.musicalService = musicalService;
+        this.rankAPIClient = rankAPIClient;
+    }
+
+//    @Scheduled(cron = "0 0 1 * * ?") 새벽 1시마다 db 자동 업데이트
+    @Scheduled(initialDelay = 5000, fixedDelay = 300000000)
+    @Transactional
+    @Override
+    public void updateMonthData() {
+
+        try {
+            RankResponse response = rankAPIClient.fetchMonthRank();
+            log.info("end fetchMonthRank");
+            saveMonthRankToDB(response);
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.API_RANK_BAD_REQUEST);
+        }
+
+    }
+
+    @Transactional
+    public void saveMonthRankToDB(RankResponse response) {
+        log.info("start saveMonthRankToDB");
+        List<RankItem> itemList = response.getRankItems();
+        log.info("진행상황 확인(item list 꺼냄)");
+        String[] dates = response.getBaseDate().split("~");
+        log.info("진행상황 확인(날짜 배열 생성): " + dates[0] +" with " + dates[1]);
+        Timestamp startDate = timeStampConverter(dates[0]);
+        log.info("timeStampConverter startDate: " + startDate);
+        Timestamp endDate = timeStampConverter(dates[1]);
+        log.info("timeStampConverter endDate: " + endDate);
+
+        for (int i = 0; i < 10; i++) {
+            log.info("진행상황 확인(월별 순위 반복분 진입)");
+            RankItem MonthItem = itemList.get(i);
+            String title = normalizeTitle(MonthItem.getTitle());
+            log.info("api가 가져온 제목: " + title);
+            String area = MonthItem.getArea();
+            log.info("api가 가져온 지역: " + area);
+            String region;
+            switch (area) {
+                case "서울":
+                    region = "서울특별시";
+                    break;
+                case "경기":
+                    region = "경기도";
+                    break;
+                case "인천":
+                    region = "인천광역시";
+                    break;
+                case "세종":
+                    region = "세종특별자치시";
+                    break;
+                case "대전":
+                    region = "대전광역시";
+                    break;
+                case "대구":
+                    region = "대구광역시";
+                    break;
+                case "광주":
+                    region = "광주광역시";
+                    break;
+                case "부산":
+                    region = "부산광역시";
+                    break;
+                case "울산":
+                    region = "울산광역시";
+                    break;
+                case "강원":
+                    region = "강원도";
+                    break;
+                case "충북":
+                    region = "충청북도";
+                    break;
+                case "충남":
+                    region = "충청남도";
+                    break;
+                case "전북":
+                    region = "전라북도";
+                    break;
+                case "전남":
+                    region = "전라남도";
+                    break;
+                case "경북":
+                    region = "경상북도";
+                    break;
+                case "경남":
+                    region = "경상남도";
+                    break;
+                case "제주":
+                    region = "제주특별자치도";
+                    break;
+                default:
+                    region = area; // 일치하는 케이스가 없을 경우 원래 값을 유지
+                    break;
+            }
+            MusicalDTO musicalDTO = musicalService.findMusicalDetailByName(title);
+            log.info("찾아온 musicalDTO: " + musicalDTO);
+            PerformanceDTO performanceDTO =
+                    performanceService.findPerformanceByMusicalIdAndRegion(musicalDTO.getMusicalId(), region);
+            log.info("찾아온 performanceDTO: " + performanceDTO);
+
+            PerformanceRank performanceRank = new PerformanceRank();
+            performanceRank.setMusicalId(musicalDTO.getMusicalId());
+            performanceRank.setPerformanceId(performanceDTO.getPerformanceId());
+            performanceRank.setRankType(RankType.MONTHLY);
+            performanceRank.setStartDate(startDate);
+            performanceRank.setEndDate(endDate);
+            performanceRank.setRank(MonthItem.getRank());
+
+            performanceRankRepository.save(performanceRank);
+        }
+    }
+
+    @Scheduled(initialDelay = 5000, fixedDelay = 300000000)
+    @Transactional
+    @Override
+    public void updateDayData() {
+        try {
+            RankResponse response = rankAPIClient.fetchDayRank();
+            saveDayRankToDB(response);
+        } catch (Exception e) {
+            throw new CommonException(ErrorCode.API_RANK_BAD_REQUEST);
+        }
+    }
+
+    @Transactional
+    public void saveDayRankToDB(RankResponse response) {
+        List<RankItem> itemList = response.getRankItems();
+        String date = response.getBaseDate();
+        Timestamp startDate = timeStampConverter(date);
+
+        for (int i = 0; i < 10; i++) {
+            RankItem DayItem = itemList.get(i);
+            String title = normalizeTitle(DayItem.getTitle());
+            log.info("파싱된 title: " + title);
+            String area = DayItem.getArea();
+            log.info("api가 가져온 지역: " + area);
+            String region;
+            switch (area) {
+                case "서울":
+                    region = "서울특별시";
+                    break;
+                case "경기":
+                    region = "경기도";
+                    break;
+                case "인천":
+                    region = "인천광역시";
+                    break;
+                case "세종":
+                    region = "세종특별자치시";
+                    break;
+                case "대전":
+                    region = "대전광역시";
+                    break;
+                case "대구":
+                    region = "대구광역시";
+                    break;
+                case "광주":
+                    region = "광주광역시";
+                    break;
+                case "부산":
+                    region = "부산광역시";
+                    break;
+                case "울산":
+                    region = "울산광역시";
+                    break;
+                case "강원":
+                    region = "강원도";
+                    break;
+                case "충북":
+                    region = "충청북도";
+                    break;
+                case "충남":
+                    region = "충청남도";
+                    break;
+                case "전북":
+                    region = "전라북도";
+                    break;
+                case "전남":
+                    region = "전라남도";
+                    break;
+                case "경북":
+                    region = "경상북도";
+                    break;
+                case "경남":
+                    region = "경상남도";
+                    break;
+                case "제주":
+                    region = "제주특별자치도";
+                    break;
+                default:
+                    region = area; // 일치하는 케이스가 없을 경우 원래 값을 유지
+                    break;
+            }
+            MusicalDTO musicalDTO = musicalService.findMusicalDetailByName(title);
+            log.info("찾아온 musicalDTO: " + musicalDTO);
+
+            PerformanceDTO performanceDTO =
+                    performanceService.findPerformanceByMusicalIdAndRegion(musicalDTO.getMusicalId(), region);
+            log.info("찾아온 performanceDTO: " + performanceDTO);
+
+            PerformanceRank performanceRank = new PerformanceRank();
+            performanceRank.setMusicalId(musicalDTO.getMusicalId());
+            performanceRank.setPerformanceId(performanceDTO.getPerformanceId());
+            performanceRank.setRank(DayItem.getRank());
+            performanceRank.setStartDate(startDate);
+            performanceRank.setEndDate(startDate);
+            performanceRank.setRankType(RankType.DAILY);
+
+            performanceRankRepository.save(performanceRank);
+        }
+    }
+
+    private String normalizeTitle(String title) {
+        return title.replaceAll("\\[.*?\\]", "")  // 대괄호와 그 내용 제거 (지역 정보)
+                .replaceAll("\\(.*?\\)", "")  // 소괄호와 그 내용 제거
+                .replaceAll("\\s+", "")       // 모든 공백 제거
+                .toLowerCase()                // 소문자로 변환
+                .trim();               // 소문자로 변환
+    }
+
+    private Timestamp timeStampConverter(String Date) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        LocalDate localDate = LocalDate.parse(Date, formatter);
+
+        LocalDateTime localDateTime = localDate.atStartOfDay();
+
+        return Timestamp.valueOf(localDateTime);
+    }
+}


### PR DESCRIPTION
---
name: ADD: 뮤지컬과 공연 정보를 저장하는 API 로직 수정 및 공연 순위를 저장하는 API 기능 추가
about: 뮤지컬과 공연 정보를 저장하는 api 로직을 수정했고, 공연 순위를 저장하는 api 기능을 추가했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [x] 기능 수정
- [x] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 
<img width="630" alt="image" src="https://github.com/user-attachments/assets/068919bf-9d85-4195-94d1-55e7876fb6ea">

## 테스트 계획 또는 완료 사항
- [x] 공연 및 뮤지컬 저장
- [x] 공연 순위 저장
