### PR TITLE
ADD: 월간 랭킹 리스트와 일간 랭킹 리스트를 볼 수 있는 기능을 추가

### DIFF
--- a/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/musical/service/MusicalServiceImpl.java
@@ -66,8 +66,6 @@ public class MusicalServiceImpl implements MusicalService {
                 .map(Musical::getMusicalId)
                 .collect(Collectors.toList());
 
-        Map<Long, String> averageScopes = scopeService.calculateAverageScopeBatch(musicalIds);
-
         List<MusicalListDTO> dtoList = musicalPage.getContent().stream()
                 .map(musical -> {
                     MusicalListDTO dto = new MusicalListDTO();
@@ -75,7 +73,6 @@ public class MusicalServiceImpl implements MusicalService {
                     dto.setMusicalId(musical.getMusicalId());
                     dto.setPoster(musical.getPoster());
                     dto.setTitle(musical.getTitle());
-                    dto.setAverageScope(averageScopes.get(musical.getMusicalId()));
                     return dto;
                 }).collect(Collectors.toList());
         // 전체 데이터셋의 총 항목 수를 나타냄.

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/controller/PerformanceController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/controller/PerformanceController.java
@@ -1,0 +1,65 @@
+package com.threeping.mudium.performance.controller;
+
+import com.threeping.mudium.common.ResponseDTO;
+import com.threeping.mudium.performance.dto.PerformanceDTO;
+import com.threeping.mudium.performance.dto.PerformanceRankDTO;
+import com.threeping.mudium.performance.service.PerformanceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/performance")
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    @Autowired
+    public PerformanceController(PerformanceService performanceService) {
+        this.performanceService = performanceService;
+    }
+
+    // 뮤지컬 상세조회를 했을 때 모든 공연을 주기 위한 핸들러 메서드
+    @GetMapping("/{musicalId}")
+    public ResponseDTO<?> findPerformances(@PathVariable Long musicalId) {
+        List<PerformanceDTO> dtoList = performanceService.findPerformances(musicalId);
+
+        ResponseDTO<List<PerformanceDTO>> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(dtoList);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        responseDTO.setSuccess(true);
+
+        return responseDTO;
+    }
+
+    // 메인 페이지에서 월간 랭킹을 주기 위한 핸들러 메서드
+    @GetMapping("/rank/month")
+    public ResponseDTO<?> findMonthPerformancesRank() {
+        List<PerformanceRankDTO> monthRankList = performanceService.findMonthRank();
+
+        ResponseDTO<List<PerformanceRankDTO>> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(monthRankList);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        responseDTO.setSuccess(true);
+
+        return responseDTO;
+    }
+
+    // 메인 페이지에서 일간 랭킹을 주기 위한 핸들러 메서드
+    @GetMapping("/rank/day")
+    public ResponseDTO<?> findDayPerformancesRank() {
+        List<PerformanceRankDTO> dayRankList = performanceService.findDayRank();
+
+        ResponseDTO<List<PerformanceRankDTO>> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(dayRankList);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        responseDTO.setSuccess(true);
+
+        return responseDTO;
+    }
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceRankDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/dto/PerformanceRankDTO.java
@@ -1,4 +1,4 @@
-package com.threeping.mudium.musical.dto;
+package com.threeping.mudium.performance.dto;
 
 import lombok.*;
 
@@ -7,7 +7,7 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-public class MusicalListDTO {
+public class PerformanceRankDTO {
 
     private Long musicalId;
 
@@ -15,4 +15,7 @@ public class MusicalListDTO {
 
     private String poster;
 
+    private String region;
+
+    private Integer rank;
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRankRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRankRepository.java
@@ -1,9 +1,27 @@
 package com.threeping.mudium.performance.repository;
 
 import com.threeping.mudium.performance.aggregate.PerformanceRank;
+import com.threeping.mudium.performance.aggregate.RankType;
+import com.threeping.mudium.performance.dto.PerformanceRankDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 @Repository
 public interface PerformanceRankRepository extends JpaRepository<PerformanceRank, Long> {
+    @Query("SELECT new com.threeping.mudium.performance.dto.PerformanceRankDTO(" +
+            "pr.musicalId, m.title, m.poster, p.region, pr.rank) " +
+            "FROM rankEntity pr " +
+            "JOIN MusicalEntity m ON pr.musicalId = m.musicalId " +
+            "JOIN TBL_PERFORMANCE p ON pr.performanceId = p.performanceId " +
+            "WHERE pr.endDate = :endDate AND pr.rankType = :rankType " +
+            "ORDER BY pr.rank")
+    List<PerformanceRankDTO> findRankDTOs(
+            @Param("endDate") Timestamp endDate,
+            @Param("rankType") RankType rankType
+    );
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/repository/PerformanceRepository.java
@@ -2,8 +2,6 @@ package com.threeping.mudium.performance.repository;
 
 import com.threeping.mudium.performance.aggregate.Performance;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceService.java
@@ -2,6 +2,7 @@ package com.threeping.mudium.performance.service;
 
 import com.threeping.mudium.musical.aggregate.Musical;
 import com.threeping.mudium.performance.dto.PerformanceDTO;
+import com.threeping.mudium.performance.dto.PerformanceRankDTO;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +11,8 @@ public interface PerformanceService {
     List<PerformanceDTO> findPerformances(Long musicalId);
 
     PerformanceDTO findPerformanceByMusicalIdAndRegion(Long musicalId, String region);
+
+    List<PerformanceRankDTO> findMonthRank();
+
+    List<PerformanceRankDTO> findDayRank();
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceServiceImpl.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/performance/service/PerformanceServiceImpl.java
@@ -4,24 +4,35 @@ import com.threeping.mudium.common.exception.CommonException;
 import com.threeping.mudium.common.exception.ErrorCode;
 import com.threeping.mudium.musical.aggregate.Musical;
 import com.threeping.mudium.performance.aggregate.Performance;
+import com.threeping.mudium.performance.aggregate.PerformanceRank;
+import com.threeping.mudium.performance.aggregate.RankType;
 import com.threeping.mudium.performance.dto.PerformanceDTO;
+import com.threeping.mudium.performance.dto.PerformanceRankDTO;
+import com.threeping.mudium.performance.repository.PerformanceRankRepository;
 import com.threeping.mudium.performance.repository.PerformanceRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
+@Slf4j
 public class PerformanceServiceImpl implements PerformanceService {
 
     private final PerformanceRepository performanceRepository;
+    private final PerformanceRankRepository performanceRankRepository;
 
     @Autowired
-    public PerformanceServiceImpl(PerformanceRepository performanceRepository) {
+    public PerformanceServiceImpl(PerformanceRepository performanceRepository, PerformanceRankRepository performanceRankRepository) {
         this.performanceRepository = performanceRepository;
+        this.performanceRankRepository = performanceRankRepository;
     }
 
 
@@ -34,10 +45,12 @@ public class PerformanceServiceImpl implements PerformanceService {
         List<PerformanceDTO> dtoList = performanceList.stream()
                 .map(performance -> {
                     PerformanceDTO dto = new PerformanceDTO();
+                    dto.setPerformanceId(performance.getPerformanceId());
                     dto.setRegion(performance.getRegion());
                     dto.setTheater(performance.getTheater());
                     dto.setEndDate(performance.getEndDate());
                     dto.setStartDate(performance.getStartDate());
+                    dto.setMusicalId(performance.getMusicalId());
                     return dto;
                 }).collect(Collectors.toList());
         return dtoList;
@@ -57,5 +70,29 @@ public class PerformanceServiceImpl implements PerformanceService {
         dto.setStartDate(performance.getStartDate());
 
         return dto;
+    }
+
+    @Override
+    public List<PerformanceRankDTO> findDayRank() {
+        Timestamp today = getTodayTimestamp();
+        log.info("Today is {}", today);
+        List<PerformanceRankDTO> dayList = performanceRankRepository.findRankDTOs(today, RankType.DAILY);
+
+        return dayList;
+    }
+
+    @Override
+    public List<PerformanceRankDTO> findMonthRank() {
+        Timestamp today = getTodayTimestamp();
+        List<PerformanceRankDTO> monthList = performanceRankRepository.findRankDTOs(today, RankType.MONTHLY);
+
+        return monthList;
+    }
+
+    private Timestamp getTodayTimestamp() {
+        LocalDateTime now = LocalDateTime.now();
+        now = now.minusDays(1);
+        LocalDate today = now.toLocalDate();
+        return Timestamp.valueOf(today.atStartOfDay());
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/controller/ScopeController.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/controller/ScopeController.java
@@ -1,6 +1,8 @@
 package com.threeping.mudium.scope.controller;
 
+import com.threeping.mudium.common.ResponseDTO;
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
+import com.threeping.mudium.scope.dto.AverageScopeDTO;
 import com.threeping.mudium.scope.service.ScopeService;
 import com.threeping.mudium.scope.vo.ScopeVO;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,5 +45,16 @@ public class ScopeController {
                                             @PathVariable("musicalId") Long musicalId) {
         scopeService.deleteScope(musicalId, userId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/{musicalId}")
+    public ResponseDTO<?> getAverageScope(@PathVariable("musicalId") Long musicalId) {
+        AverageScopeDTO dto = scopeService.calculateAverageScope(musicalId);
+
+        ResponseDTO<AverageScopeDTO> responseDTO = new ResponseDTO<>();
+        responseDTO.setData(dto);
+        responseDTO.setSuccess(true);
+        responseDTO.setHttpStatus(HttpStatus.OK);
+        return responseDTO;
     }
 }

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/dto/AverageScopeDTO.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/dto/AverageScopeDTO.java
@@ -1,0 +1,15 @@
+package com.threeping.mudium.scope.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class AverageScopeDTO {
+
+    private Double scope;
+
+    private String people;
+}

--- a/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeService.java
+++ b/MUDIUM/src/main/java/com/threeping/mudium/scope/service/ScopeService.java
@@ -1,6 +1,7 @@
 package com.threeping.mudium.scope.service;
 
 import com.threeping.mudium.scope.aggregate.entity.ScopeEntity;
+import com.threeping.mudium.scope.dto.AverageScopeDTO;
 import com.threeping.mudium.scope.dto.ScopeDTO;
 import com.threeping.mudium.scope.vo.ScopeVO;
 
@@ -18,5 +19,5 @@ public interface ScopeService {
 
     List<ScopeDTO> findAllScopesByMusicalId(Long musicalId);
 
-    Map<Long, String> calculateAverageScopeBatch(List<Long> musicalIds);
+    AverageScopeDTO calculateAverageScope(Long musicalId);
 }

--- a/MUDIUM/src/test/java/com/threeping/mudium/performance/service/PerformanceServiceImplTests.java
+++ b/MUDIUM/src/test/java/com/threeping/mudium/performance/service/PerformanceServiceImplTests.java
@@ -1,0 +1,72 @@
+package com.threeping.mudium.performance.service;
+
+import com.threeping.mudium.performance.dto.PerformanceDTO;
+import com.threeping.mudium.performance.dto.PerformanceRankDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+class PerformanceServiceImplTests {
+
+    private final PerformanceService performanceService;
+
+    @Autowired
+    PerformanceServiceImplTests(PerformanceService performanceService) {
+        this.performanceService = performanceService;
+    }
+
+    @DisplayName("특정 뮤지컬의 모든 공연 리스트 조회")
+    @Test
+    void searchPerformance() {
+        // Given
+        Long musicalId = 1L;
+
+        // When
+        List<PerformanceDTO> dtoList = performanceService.findPerformances(musicalId);
+
+        // Then
+        assertNotNull(dtoList, "조회된 공연리스트는 null이 아니다.");
+        assertTrue(dtoList.get(0).getMusicalId().equals(musicalId), "조회된 리스트의 뮤지컬 번호 확인");
+    }
+
+    @DisplayName("월별 순위 리스트 조회")
+    @Test
+    void searchMonthRank() {
+        // When
+        List<PerformanceRankDTO> monthList = performanceService.findMonthRank();
+
+        for (PerformanceRankDTO dto : monthList) {
+            log.info("10개의 공연 순위 확인" + dto.toString());
+        }
+
+        // Then
+        assertNotNull(monthList, "조회된 월별 랭킹은 null이 아니다.");
+        assertTrue(monthList.size() == 10, "조회된 리스트의 공연 개수는 10개다.");
+    }
+
+    @DisplayName("일별 순위 리스트 조회")
+    @Test
+    void searchDayRank() {
+        // When
+        List<PerformanceRankDTO> monthList = performanceService.findDayRank();
+
+        for (PerformanceRankDTO dto : monthList) {
+            log.info("10개의 공연 순위 확인" + dto.toString());
+        }
+
+        // Then
+        assertNotNull(monthList, "조회된 일별 랭킹은 null이 아니다.");
+        assertTrue(monthList.size() == 10, "조회된 리스트의 공연 개수는 10개다.");
+    }
+
+}


### PR DESCRIPTION
---
name: 월간 랭킹 리스트와 일간 랭킹 리스트를 볼 수 있는 기능을 추가
about: 월간 랭킹 리스트와 일간 랭킹 리스트를 볼 수 있는 기능을 추가했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 
월간 랭킹 조회 결과
<img width="971" alt="스크린샷 2024-10-18 오후 2 21 39" src="https://github.com/user-attachments/assets/42843cdd-d65c-4a76-8831-1c0c7508be34">
일간 랭킹 조회 결과
<img width="862" alt="스크린샷 2024-10-18 오후 2 21 01" src="https://github.com/user-attachments/assets/1c79b4ab-2a2b-4e0b-a16b-d6b0314c3600">


## 테스트 계획 또는 완료 사항
- [x] 월간 랭킹 조회
- [x] 일간 랭킹 조회
